### PR TITLE
Default to SnakeCaseNamingStrategy.

### DIFF
--- a/src/GitLabApiClient/Internal/Http/Serialization/EmptyCollectionContractResolver.cs
+++ b/src/GitLabApiClient/Internal/Http/Serialization/EmptyCollectionContractResolver.cs
@@ -8,6 +8,11 @@ namespace GitLabApiClient.Internal.Http.Serialization
 {
     internal sealed class EmptyCollectionContractResolver : DefaultContractResolver
     {
+        public EmptyCollectionContractResolver()
+        {
+            NamingStrategy = new SnakeCaseNamingStrategy();
+        }
+
         protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
         {
             var property = base.CreateProperty(member, memberSerialization);


### PR DESCRIPTION
By using the SnakeCaseNamingStrategy, we can avoid having to explicitly specify the JsonProperty PropertyName for each property within a POCO.