### PR TITLE
Add missing issue weight and issue time statistics

### DIFF
--- a/src/GitLabApiClient/Models/Issues/Requests/CreateIssueRequest.cs
+++ b/src/GitLabApiClient/Models/Issues/Requests/CreateIssueRequest.cs
@@ -94,5 +94,11 @@ namespace GitLabApiClient.Models.Issues.Requests
         /// </summary>
         [JsonProperty("discussion_to_resolve")]
         public int? DiscussionToResolveId { get; set; }
+
+        /// <summary>
+        /// The weight of an issue. Valid values are greater than or equal to 0.
+        /// </summary>
+        [JsonProperty("weight")]
+        public int? Weight { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Issues/Requests/UpdateIssueRequest.cs
+++ b/src/GitLabApiClient/Models/Issues/Requests/UpdateIssueRequest.cs
@@ -91,5 +91,11 @@ namespace GitLabApiClient.Models.Issues.Requests
         /// </summary>
         [JsonProperty("due_date")]
         public string DueDate { get; set; }
+
+        /// <summary>
+        /// The weight of an issue. Valid values are greater than or equal to 0.
+        /// </summary>
+        [JsonProperty("weight")]
+        public int? Weight { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
+++ b/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
@@ -46,5 +46,8 @@ namespace GitLabApiClient.Models.Issues.Responses
         
         [JsonProperty("weight")]
         public int? Weight { get; set; }
+
+        [JsonProperty("time_stats")]
+        public IssueTimeStatistic TimeStats { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
+++ b/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
@@ -43,5 +43,8 @@ namespace GitLabApiClient.Models.Issues.Responses
 
         [JsonProperty("web_url")]
         public string WebUrl { get; set; }
+        
+        [JsonProperty("weight")]
+        public int? Weight { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Issues/Responses/IssueTimeStatistic.cs
+++ b/src/GitLabApiClient/Models/Issues/Responses/IssueTimeStatistic.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Issues.Responses
+{
+    public class IssueTimeStatistic
+    {
+
+        [JsonProperty("time_estimate")]
+        public int TimeEstimate { get; set; }
+
+        [JsonProperty("total_time_spent")]
+        public int TotalTimeSpent { get; set; }
+
+        [JsonProperty("human_time_estimate")]
+        public string HumanTimeEstimate { get; set; }
+
+        [JsonProperty("human_total_time_spent")]
+        public string HumanTotalTimeSpent { get; set; }
+    }
+}

--- a/test/GitLabApiClient.Test/IssuesClientTest.cs
+++ b/test/GitLabApiClient.Test/IssuesClientTest.cs
@@ -31,7 +31,8 @@ namespace GitLabApiClient.Test
                 Labels = new[] { "Label1" },
                 MilestoneId = 2,
                 DiscussionToResolveId = 3,
-                MergeRequestIdToResolveDiscussions = 4
+                MergeRequestIdToResolveDiscussions = 4,
+                Weight = 3
             });
 
             //act
@@ -42,7 +43,8 @@ namespace GitLabApiClient.Test
                 Description = "Description11",
                 Labels = new[] { "Label11" },
                 Title = "Title11",
-                MilestoneId = 22
+                MilestoneId = 22,
+                Weight = 33
             });
 
             //assert
@@ -51,7 +53,8 @@ namespace GitLabApiClient.Test
                 i.Confidential == false &&
                 i.Description == "Description11" &&
                 i.Labels.SequenceEqual(new[] { "Label11" }) &&
-                i.Title == "Title11");
+                i.Title == "Title11" && 
+                i.Weight == 33);
         }
 
         [Fact]

--- a/test/GitLabApiClient.Test/IssuesClientTest.cs
+++ b/test/GitLabApiClient.Test/IssuesClientTest.cs
@@ -53,7 +53,7 @@ namespace GitLabApiClient.Test
                 i.Confidential == false &&
                 i.Description == "Description11" &&
                 i.Labels.SequenceEqual(new[] { "Label11" }) &&
-                i.Title == "Title11" && 
+                i.Title == "Title11" &&
                 i.Weight == 33);
         }
 
@@ -84,7 +84,10 @@ namespace GitLabApiClient.Test
             var listedIssues = await _sut.GetAsync(TestProjectTextId, o => o.Filter = title);
 
             //assert
-            listedIssues.Single().Title.Should().Be(title);
+            listedIssues.Single().Should().Match<Issue>(i =>
+                i.ProjectId == TestProjectTextId &&
+                i.Title == title &&
+                i.TimeStats != null);
         }
 
         [Fact]


### PR DESCRIPTION
Adding missing properties (weight and time stats) in the response model of the gitlab issue client #12 