### PR TITLE
Enabled tests for feature/branches

### DIFF
--- a/test/GitLabApiClient.Test/ReleasesTest.cs
+++ b/test/GitLabApiClient.Test/ReleasesTest.cs
@@ -11,8 +11,8 @@ using System.Collections.Generic;
 namespace GitLabApiClient.Test
 {
     [Trait("Category", "LinuxIntegration")]
-    [Collection("GitlabContainerFixture")]
-    class ReeasesTest
+    [Collection("GitLabContainerFixture")]
+    public class ReeasesTest
     {
         private readonly ReleaseClient _sut = new ReleaseClient(GetFacade(), new ReleaseQueryBuilder());
         


### PR DESCRIPTION
On my previous PR I forgot to make the class ReleasesTest class public, so the tests would not have been run.

Sry, my fault - pease merge :) 