### PR TITLE
 BUG FIX: repository keyword was missing in the request url for TagClient->GetAsync

### DIFF
--- a/src/GitLabApiClient/TagClient.cs
+++ b/src/GitLabApiClient/TagClient.cs
@@ -23,22 +23,27 @@ namespace GitLabApiClient
         }
 
         public async Task<Tag> GetAsync(string projectId, string tagName) =>
-            await _httpFacade.Get<Tag>($"projects/{projectId}/repository/tags/{tagName}");
+            await _httpFacade.Get<Tag>(TagsBaseUrl(projectId) + "/{tagName}");
 
         public async Task<IList<Tag>> GetAsync(string projectId, Action<TagQueryOptions> options)
         {
             var queryOptions = new TagQueryOptions(projectId);
             options?.Invoke(queryOptions);
 
-            string url = _tagQueryBuilder.Build($"projects/{projectId}/tags", queryOptions);
+            string url = _tagQueryBuilder.Build(TagsBaseUrl(projectId), queryOptions);
             return await _httpFacade.GetPagedList<Tag>(url);
         }
 
         public async Task<Tag> CreateAsync(CreateTagRequest request) =>
-            await _httpFacade.Post<Tag>($"projects/{request.ProjectId}/repository/tags", request);
+            await _httpFacade.Post<Tag>(TagsBaseUrl(request.ProjectId), request);
 
         public async Task DeleteAsync(DeleteTagRequest request) =>
-            await _httpFacade.Delete($"projects/{request.ProjectId}/repository/tags/{request.TagName}");
+            await _httpFacade.Delete(TagsBaseUrl(request.ProjectId) + "/{request.TagName}");
 
+        public static string TagsBaseUrl(string projectId)
+        {
+            string baseUrl = $"projects/{projectId}/repository/tags";
+            return baseUrl;
+        }
     }
 }

--- a/test/GitLabApiClient.Test/TagsClientTest.cs
+++ b/test/GitLabApiClient.Test/TagsClientTest.cs
@@ -1,0 +1,19 @@
+using FluentAssertions;
+using Xunit;
+
+namespace GitLabApiClient.Test
+{
+    [Trait("Category", "LinuxIntegration")]
+    [Collection("GitLabContainerFixture")]
+    public class TagsClientTest
+    {
+        private const string ProjectId = "testProjectId";
+
+        [Fact]
+        public void TagsBaseUrlTest()
+        {
+            string baseUrl = TagClient.TagsBaseUrl(ProjectId);
+            baseUrl.Should().Be("projects/" + ProjectId + "/repository/tags");
+        }
+    }
+}


### PR DESCRIPTION
Fixes a problem with TagClient->GetAsync