### PR TITLE
Release API has no query paramaters

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
@@ -9,11 +9,6 @@ namespace GitLabApiClient.Internal.Queries
     {
         protected override void BuildCore(ReleaseQueryOptions options)
         {
-            if (!string.IsNullOrEmpty(options.ProjectId))
-                Add("id", options.ProjectId);
-
-            if (!string.IsNullOrEmpty(options.TagName))
-                Add("tag_name", options.TagName);
         }
     }
 }

--- a/src/GitLabApiClient/Models/Releases/Requests/ReleaseQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Releases/Requests/ReleaseQueryOptions.cs
@@ -7,9 +7,8 @@ namespace GitLabApiClient.Models.Releases.Requests
 {
     public sealed class ReleaseQueryOptions
     {
-        public string ProjectId { get; set; }
-        public string TagName { get; set; }
-
-        internal ReleaseQueryOptions(string projectId = null) => ProjectId = projectId;
+        internal ReleaseQueryOptions()
+        {
+        }
     }
 }

--- a/src/GitLabApiClient/ReleaseClient.cs
+++ b/src/GitLabApiClient/ReleaseClient.cs
@@ -27,7 +27,7 @@ namespace GitLabApiClient
 
         public async Task<IList<Release>> GetAsync(string projectId, Action<ReleaseQueryOptions> options = null)
         {
-            var queryOptions = new ReleaseQueryOptions(projectId);
+            var queryOptions = new ReleaseQueryOptions();
             options?.Invoke(queryOptions);
 
             string url = _releaseQueryBuilder.Build($"projects/{projectId}/releases", queryOptions);

--- a/test/GitLabApiClient.Test/ReleasesTest.cs
+++ b/test/GitLabApiClient.Test/ReleasesTest.cs
@@ -15,7 +15,7 @@ namespace GitLabApiClient.Test
     public class ReeasesTest
     {
         private readonly ReleaseClient _sut = new ReleaseClient(GetFacade(), new ReleaseQueryBuilder());
-        
+
         [Fact]
         public async Task CreatedReleaseCanBeUpdated()
         {
@@ -24,7 +24,7 @@ namespace GitLabApiClient.Test
 
             //act
             var updatedRelease = await _sut.UpdateAsync(new UpdateReleaseRequest(TestProjectTextId, TestRelease, TestTagName, "Updated Description", DateTime.MinValue));
-            
+
             //assert
             updatedRelease.Should().Match<Release>(i =>
                 i.ProjectId == TestProjectTextId &&
@@ -57,7 +57,7 @@ namespace GitLabApiClient.Test
             var createdRelease = await _sut.CreateAsync(new CreateReleaseRequest(TestProjectTextId, TestRelease, TestTagName, TestDescription, DateTime.MinValue));
 
             //act
-            var releaseList = await _sut.GetAsync(TestProjectTextId, o => o.TagName = TestTagName);
+            var releaseList = await _sut.GetAsync(TestProjectTextId);
 
             //assert
             releaseList[0].Should().Match<Release>(i =>


### PR DESCRIPTION
Seems like someone added the path parameters to the query builder, which seems wrong.

https://docs.gitlab.com/ee/api/releases/#list-releases