### PR TITLE
fix Tags API does not have a id query param, id is a path param

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/TagQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/TagQueryBuilder.cs
@@ -9,9 +9,6 @@ namespace GitLabApiClient.Internal.Queries
     {
         protected override void BuildCore(TagQueryOptions options)
         {
-            if (!string.IsNullOrEmpty(options.ProjectId))
-                Add("id", options.ProjectId);
-
             if (!string.IsNullOrEmpty(options.Search))
                 Add("search", options.Search);
 

--- a/src/GitLabApiClient/Models/Tags/Requests/TagQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Tags/Requests/TagQueryOptions.cs
@@ -6,11 +6,12 @@ namespace GitLabApiClient.Models.Tags.Requests
 {
     public sealed class TagQueryOptions
     {
-        public string ProjectId { get; set; }
         public string Search { get; set; }
         public TagOrder OrderBy { get; set; } = TagOrder.NAME;
         public TagSort Sort { get; set; } = TagSort.DESC;
 
-        internal TagQueryOptions(string projectId = null) => ProjectId = projectId;
+        internal TagQueryOptions()
+        {
+        }
     }
 }

--- a/src/GitLabApiClient/TagClient.cs
+++ b/src/GitLabApiClient/TagClient.cs
@@ -27,7 +27,7 @@ namespace GitLabApiClient
 
         public async Task<IList<Tag>> GetAsync(string projectId, Action<TagQueryOptions> options)
         {
-            var queryOptions = new TagQueryOptions(projectId);
+            var queryOptions = new TagQueryOptions();
             options?.Invoke(queryOptions);
 
             string url = _tagQueryBuilder.Build(TagsBaseUrl(projectId), queryOptions);


### PR DESCRIPTION
I agree that GitLab API docs can be confusing 😅 However id param is a path param as shown in the URL example: `GET /projects/:id/repository/tags`

https://docs.gitlab.com/ee/api/tags/#list-tags