### PR TITLE
fix Merge Request API, id is a path param not a query param

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsQueryBuilder.cs
@@ -12,7 +12,6 @@ namespace GitLabApiClient.Internal.Queries
                 return;
             }
 
-            Add("id", projectOptions.ProjectId);
             Add(projectOptions.MergeRequestsIds);
             base.BuildCore(options);
         }

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -40,7 +40,7 @@ namespace GitLabApiClient
         /// <returns>Merge requests satisfying options.</returns>
         public async Task<IList<MergeRequest>> GetAsync(int projectId, Action<ProjectMergeRequestsQueryOptions> options = null)
         {
-            var projectMergeRequestOptions = new ProjectMergeRequestsQueryOptions(projectId);
+            var projectMergeRequestOptions = new ProjectMergeRequestsQueryOptions();
             options?.Invoke(projectMergeRequestOptions);
 
             string query = _projectMergeRequestsQueryBuilder.

--- a/src/GitLabApiClient/Models/MergeRequests/Requests/ProjectMergeRequestsQueryOptions.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Requests/ProjectMergeRequestsQueryOptions.cs
@@ -12,12 +12,9 @@ namespace GitLabApiClient.Models.MergeRequests.Requests
         /// Initializes a new instance of ProjectMergeRequestsQueryOptions.
         /// </summary>
         /// <param name="projectId">The ID of a project.</param>
-        internal ProjectMergeRequestsQueryOptions(int projectId) => ProjectId = projectId;
-
-        /// <summary>
-        /// The ID of a project
-        /// </summary>
-        public int ProjectId { get; }
+        internal ProjectMergeRequestsQueryOptions()
+        {
+        }
 
         /// <summary>
         /// Return the request having the given ids.

--- a/src/GitLabApiClient/Models/MergeRequests/Requests/ProjectMergeRequestsQueryOptions.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Requests/ProjectMergeRequestsQueryOptions.cs
@@ -11,7 +11,6 @@ namespace GitLabApiClient.Models.MergeRequests.Requests
         /// <summary>
         /// Initializes a new instance of ProjectMergeRequestsQueryOptions.
         /// </summary>
-        /// <param name="projectId">The ID of a project.</param>
         internal ProjectMergeRequestsQueryOptions()
         {
         }

--- a/test/GitLabApiClient.Test/Internal/Queries/ProjectMergeRequestsQueryBuilderTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Queries/ProjectMergeRequestsQueryBuilderTest.cs
@@ -16,7 +16,7 @@ namespace GitLabApiClient.Test.Internal.Queries
 
             string query = sut.Build(
                 "https://gitlab.com/api/v4/merge_requests",
-                new ProjectMergeRequestsQueryOptions(3)
+                new ProjectMergeRequestsQueryOptions()
                 {
                     MergeRequestsIds = new[] { 4, 5 },
                     State = QueryMergeRequestState.Opened,
@@ -33,7 +33,6 @@ namespace GitLabApiClient.Test.Internal.Queries
                 });
 
             query.Should().Be("https://gitlab.com/api/v4/merge_requests?" +
-                              "id=3&" +
                               "iids%5b%5d=4&iids%5b%5d=5&" +
                               "state=opened&" +
                               "order_by=updated_at&" +


### PR DESCRIPTION
https://gitlab.com/api/v4/merge_requests?id=3 ignores id and returns all your open merge requests

https://docs.gitlab.com/ee/api/merge_requests.html