### PR TITLE
fix branch client url and query params

### DIFF
--- a/src/GitLabApiClient/BranchClient.cs
+++ b/src/GitLabApiClient/BranchClient.cs
@@ -23,22 +23,22 @@ namespace GitLabApiClient
         }
 
         public async Task<Branch> GetAsync(string projectId, string branchName) =>
-            await _httpFacade.Get<Branch>($"projects/{projectId}/branches/{branchName}");
+            await _httpFacade.Get<Branch>($"projects/{projectId}/repository/branches/{branchName}");
 
         public async Task<IList<Branch>> GetAsync(string projectId, Action<BranchQueryOptions> options)
         {
-            var queryOptions = new BranchQueryOptions(projectId);
+            var queryOptions = new BranchQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _branchQueryBuilder.Build($"projects/{projectId}/branches", queryOptions);
+            string url = _branchQueryBuilder.Build($"projects/{projectId}/repository/branches", queryOptions);
             return await _httpFacade.GetPagedList<Branch>(url);
         }
 
         public async Task<Branch> CreateAsync(CreateBranchRequest request) =>
-            await _httpFacade.Post<Branch>($"projects/{request.ProjectId}/branches", request);
+            await _httpFacade.Post<Branch>($"projects/{request.ProjectId}/repository/branches", request);
 
         public async Task DeleteBranch(DeleteBranchRequest request) =>
-            await _httpFacade.Delete($"projects/{request.ProjectId}/releases/{request.BranchName}");
+            await _httpFacade.Delete($"projects/{request.ProjectId}/repository/branches/{request.BranchName}");
 
         public async Task DeleteMergedBranches(DeleteMergedBranchesRequest request) =>
             await _httpFacade.Delete($"projects/{request.ProjectId}/repository/merged_branches");

--- a/src/GitLabApiClient/Internal/Queries/BranchQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/BranchQueryBuilder.cs
@@ -9,11 +9,8 @@ namespace GitLabApiClient.Internal.Queries
     {
         protected override void BuildCore(BranchQueryOptions options)
         {
-            if (!string.IsNullOrEmpty(options.ProjectId))
-                Add("id", options.ProjectId);
-
-            if (!string.IsNullOrEmpty(options.BranchName))
-                Add("branch", options.BranchName);
+            if (!string.IsNullOrEmpty(options.Search))
+                Add("search", options.Search);
         }
     }
 }

--- a/src/GitLabApiClient/Models/Branches/Requests/BranchQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Branches/Requests/BranchQueryOptions.cs
@@ -6,9 +6,10 @@ namespace GitLabApiClient.Models.Branches.Requests
 {
     public sealed class BranchQueryOptions
     {
-        public string ProjectId { get; set; }
-        public string BranchName { get; set; }
+        public string Search { get; set; }
 
-        internal BranchQueryOptions(string projectId = null) => ProjectId = projectId;
+        internal BranchQueryOptions()
+        {
+        }
     }
 }


### PR DESCRIPTION
fixed up URLs, `projects/{projectId}/branches` returns 404
branch query parameters only have a `search` option

https://docs.gitlab.com/ee/api/branches.html