### PR TITLE
add transfer project namespace

### DIFF
--- a/src/GitLabApiClient/Models/Projects/Requests/TransferProjectRequest.cs
+++ b/src/GitLabApiClient/Models/Projects/Requests/TransferProjectRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Projects.Requests
+{
+    public class TransferProjectRequest
+    {
+        /// <summary>
+        /// The ID or path of the namespace to transfer to project to
+        /// </summary>
+        [JsonProperty("namespace")]
+        public string NameSpace { get; set; }
+    }
+}

--- a/src/GitLabApiClient/ProjectsClient.cs
+++ b/src/GitLabApiClient/ProjectsClient.cs
@@ -39,7 +39,7 @@ namespace GitLabApiClient
             await _httpFacade.Get<Project>($"projects/{projectId}");
 
         /// <summary>
-        /// Get a list of visible projects for authenticated user. 
+        /// Get a list of visible projects for authenticated user.
         /// When accessed without authentication, only public projects are returned.
         /// </summary>
         /// <param name="options">Query options.</param>
@@ -190,5 +190,11 @@ namespace GitLabApiClient
         /// <param name="id">Id of the project.</param>
         public async Task UnArchiveAsync(int id) =>
             await _httpFacade.Post($"projects/{id}/unarchive");
+
+        public async Task<Project> Transfer(string id, TransferProjectRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+            return await _httpFacade.Put<Project>($"projects/{id}/transfer", request);
+        }
     }
 }


### PR DESCRIPTION
similar to https://github.com/jdalrymple/node-gitlab/pull/145

Added in 11.1:
docs.gitlab.com/ee/api/projects.html#transfer-a-project-to-a-new-namespace
about.gitlab.com/2018/07/22/gitlab-11-1-released/#transfer-projects-between-namespaces-via-api

The new thing is that you can transfer a project to another user or another group while the group api only allows to move to a group