### PR TITLE
#74: Fix for empty (not null) header values

### DIFF
--- a/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using GitLabApiClient.Internal.Utilities;
 
 namespace GitLabApiClient.Internal.Http
 {
@@ -107,7 +108,7 @@ namespace GitLabApiClient.Internal.Http
                 return toReturn;
 
             string valueString = headerValues.FirstOrDefault();
-            return valueString == null ? toReturn : (T)Convert.ChangeType(valueString, typeof(T));
+            return valueString.IsNullOrEmpty() ? toReturn : (T)Convert.ChangeType(valueString, typeof(T));
         }
     }
 }

--- a/test/GitLabApiClient.Test/Internal/Http/HttpResponseHeadersExtensionsTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Http/HttpResponseHeadersExtensionsTest.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using GitLabApiClient.Internal.Http;
+using Xunit;
+
+namespace GitLabApiClient.Test.Internal.Http
+{
+    public class HttpResponseHeadersExtensionsTest
+    {
+        private HttpResponseHeaders GetTestHeaders()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.Created);
+            response.Headers.Add("X-Fifty-Five", "55");
+            response.Headers.Add("X-Empty", "");
+
+            return response.Headers;
+        }
+
+        [Fact]
+        public void GetFirstHeaderValueOrDefault_WithEmptyValue_ReturnDefaultValue()
+        {
+            int expected = 0;
+            var sut = GetTestHeaders();
+
+            int result = sut.GetFirstHeaderValueOrDefault<int>("X-Empty");
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetFirstHeaderValueOrDefault_WithNotExistingKey_ReturnDefaultValue()
+        {
+            int expected = 0;
+            var sut = GetTestHeaders();
+
+            int result = sut.GetFirstHeaderValueOrDefault<int>("X-Not-Exists");
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetFirstHeaderValueOrDefault_WithValue_ReturnValue()
+        {
+            int expected = 55;
+            var sut = GetTestHeaders();
+
+            int result = sut.GetFirstHeaderValueOrDefault<int>("X-Fifty-Five");
+
+            result.Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
Fixes an error, if a header key is present, but has no (empty) value. Fixes exception for `X-Next-Page` and `X-Prev-Page`.