### PR TITLE
Remove unused csproj properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ dotnet: 3.0.100
 dist: bionic
 sudo: required
 services:
- - docker
+  - docker
 script:
- - dotnet build
- - dotnet test
+  - dotnet build
+  - dotnet test
 cache:
   directories:
-  - $HOME/.nuget
+    - $HOME/.nuget

--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -3,17 +3,12 @@
   <PropertyGroup>
     <TargetFrameworks Condition="'$(OS)' != 'Unix'">netstandard2.0;net452</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Unix'">netstandard2.0</TargetFrameworks>
-    <Version>1.0.0</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Copyright />
     <Description>GitLabApiClient is a .NET rest client for GitLab API v4.</Description>
     <Authors>nmklotas</Authors>
     <PackageProjectUrl>https://github.com/nmklotas/GitLabApiClient</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nmklotas/GitLabApiClient</RepositoryUrl>
-    <RepositoryType />
     <PackageTags>GitLab REST API CI Client</PackageTags>
     <PackageId>GitLabApiClient</PackageId>
     <Company>nmklotas</Company>


### PR DESCRIPTION
With the addition of GitVersion we do not need to specify version in csproj.
RepositoryType defaults to git.