### PR TITLE
Add WebUrl property to Commit

### DIFF
--- a/src/GitLabApiClient/Models/Commits/Responses/Commit.cs
+++ b/src/GitLabApiClient/Models/Commits/Responses/Commit.cs
@@ -32,6 +32,8 @@ namespace GitLabApiClient.Models.Commits.Responses
         public string Message { get; set; }
         [JsonProperty("parent_ids")]
         public List<string> ParentIds { get; } = new List<string>();
+        [JsonProperty("web_url")]
+        public string WebUrl { get; set; }
 
     }
 }


### PR DESCRIPTION
Issues, Merge Requests and Milestones expose a `WebUrl` property that contains the link to the GitLab web interface for the item.
The `Commit` class does not have such a property, but the server response includes it (according to the [GitLab API docs](https://docs.gitlab.com/ee/api/commits.html))

This PR adds the `WebUrl` property to the `Commit` class as well.

The PR also adds a `global.json` to pin the .NET Core SDK version to 3.1.100 because the build seems to be broken on the recently released SDK 3.1.200 (https://github.com/dotnet/sdk/issues/10878)