### PR TITLE
Add opportunity to retrieve merge request discussions and award emojis.

### DIFF
--- a/src/GitLabApiClient/IssuesClient.cs
+++ b/src/GitLabApiClient/IssuesClient.cs
@@ -137,7 +137,7 @@ namespace GitLabApiClient
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="issueIid">Iid of the issue.</param>
         /// <param name="options">IssueNotes retrieval options.</param>
-        /// <returns>Issues satisfying options.</returns>
+        /// <returns>Notes satisfying options.</returns>
         public async Task<IList<Note>> GetNotesAsync(ProjectId projectId, int issueIid, Action<IssueNotesQueryOptions> options = null)
         {
             var queryOptions = new IssueNotesQueryOptions();

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Paths;
 using GitLabApiClient.Internal.Queries;
+using GitLabApiClient.Models.AwardEmojis.Responses;
+using GitLabApiClient.Models.Discussions.Responses;
 using GitLabApiClient.Models.MergeRequests.Requests;
 using GitLabApiClient.Models.MergeRequests.Responses;
 using GitLabApiClient.Models.Notes.Requests;
@@ -128,5 +130,22 @@ namespace GitLabApiClient
             string url = _projectMergeRequestNotesQueryBuilder.Build($"projects/{projectId}/merge_requests/{mergeRequestIid}/notes", queryOptions);
             return await _httpFacade.GetPagedList<Note>(url);
         }
+
+        /// <summary>
+        /// Retrieves discussions of a merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">Iid of the merge request.</param>
+        public async Task<IList<Discussion>> GetDiscussionsAsync(ProjectId projectId, int mergeRequestIid) =>
+            await _httpFacade.GetPagedList<Discussion>($"projects/{projectId}/merge_requests/{mergeRequestIid}/discussions");
+
+        /// <summary>
+        /// Retrieves a list of all award emoji for a specified merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">The Internal Merge Request Id.</param>
+        public async Task<IList<AwardEmoji>> GetAwardEmojisAsync(ProjectId projectId, int mergeRequestIid) =>
+            await _httpFacade.GetPagedList<AwardEmoji>($"projects/{projectId}/merge_requests/{mergeRequestIid}/award_emoji");
+
     }
 }

--- a/src/GitLabApiClient/Models/AwardEmojis/Responses/AwardEmoji.cs
+++ b/src/GitLabApiClient/Models/AwardEmojis/Responses/AwardEmoji.cs
@@ -1,0 +1,31 @@
+using GitLabApiClient.Models.Users.Responses;
+using Newtonsoft.Json;
+using System;
+
+namespace GitLabApiClient.Models.AwardEmojis.Responses
+{
+    public sealed class AwardEmoji
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("user")]
+        public User User { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        [JsonProperty("awardable_id")]
+        public int AwardableId { get; set; }
+
+        [JsonProperty("awardable_type")]
+        public AwardableType AwardableType { get; set; }
+
+    }
+}

--- a/src/GitLabApiClient/Models/AwardEmojis/Responses/AwardableType.cs
+++ b/src/GitLabApiClient/Models/AwardEmojis/Responses/AwardableType.cs
@@ -1,0 +1,10 @@
+namespace GitLabApiClient.Models.AwardEmojis.Responses
+{
+    public enum AwardableType
+    {
+        Issue,
+        MergeRequest,
+        Note,
+        Snippet,
+    }
+}

--- a/src/GitLabApiClient/Models/Discussions/Responses/Discussion.cs
+++ b/src/GitLabApiClient/Models/Discussions/Responses/Discussion.cs
@@ -1,0 +1,19 @@
+using GitLabApiClient.Models.Notes.Responses;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace GitLabApiClient.Models.Discussions.Responses
+{
+    public sealed class Discussion
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("individual_note")]
+        public bool IndividualNote { get; set; }
+
+        [JsonProperty("notes")]
+        public IList<Note> Notes { get; set; } = new List<Note>();
+
+    }
+}


### PR DESCRIPTION
Added GetDiscussionsAsync and GetAwardEmojisAsync methods to MergeRequestsClient, that correspond to [List project merge request discussion items](https://docs.gitlab.com/ee/api/discussions.html#list-project-merge-request-discussion-items) and [List an awardable’s award emoji](https://docs.gitlab.com/ee/api/award_emoji.html#list-an-awardables-award-emoji) api endpoints.
Added AwardEmoji, Discussion models, AwardableType enum.
Fixed typo in IssuesClient.GetNotesAsync returns documentation tag.