### PR TITLE
No need for thread safety in most cases.

### DIFF
--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -16,7 +16,6 @@ namespace GitLabApiClient.Internal.Http
     {
         private const string PrivateToken = "PRIVATE-TOKEN";
 
-        private readonly object _locker = new object();
         private readonly HttpClient _httpClient;
         private GitLabApiRequestor _requestor;
         private GitLabApiPagedRequestor _pagedRequestor;
@@ -91,13 +90,10 @@ namespace GitLabApiClient.Internal.Http
             string url = $"{_httpClient.BaseAddress.GetLeftPart(UriPartial.Authority)}/oauth/token";
             var accessTokenResponse = await _requestor.Post<AccessTokenResponse>(url, accessTokenRequest);
 
-            lock (_locker)
-            {
-                if (_httpClient.DefaultRequestHeaders.Contains(PrivateToken))
-                    _httpClient.DefaultRequestHeaders.Remove(PrivateToken);
+            if (_httpClient.DefaultRequestHeaders.Contains(PrivateToken))
+                _httpClient.DefaultRequestHeaders.Remove(PrivateToken);
 
-                _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokenResponse.AccessToken);
-            }
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessTokenResponse.AccessToken);
 
             return accessTokenResponse;
         }


### PR DESCRIPTION
Removes thread safety but I cannot figure out why it was added in the first place.

Unless someone is running some highly parallel against the client it would be an issue.

fixes #134 