### PR TITLE
Implement last_activity_after and last_activity_before filters in Project

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/ProjectsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectsQueryBuilder.cs
@@ -47,6 +47,13 @@ namespace GitLabApiClient.Internal.Queries
 
             if (options.WithMergeRequestsEnabled)
                 Add("with_merge_requests_enabled", options.WithMergeRequestsEnabled);
+
+            if (options.LastActivityAfter.Year != 0001) //Not Default year
+                Add("last_activity_after", options.LastActivityAfter.ToUniversalTime().ToString("o")); //Format: ISO 8601 YYYY-MM-DDTHH:MM:SSZ
+
+            if (options.LastActivityBefore.Year != 0001) //Not Default year
+                Add("last_activity_before", options.LastActivityBefore.ToUniversalTime().ToString("o")); //Format: ISO 8601 YYYY-MM-DDTHH:MM:SSZ
+
         }
 
         private static string GetProjectOrderQueryValue(ProjectsOrder order)

--- a/src/GitLabApiClient/Models/Projects/Requests/ProjectQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Projects/Requests/ProjectQueryOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace GitLabApiClient.Models.Projects.Requests
 {
     /// <summary>
@@ -71,5 +73,17 @@ namespace GitLabApiClient.Models.Projects.Requests
         /// Limit by enabled merge requests feature
         /// </summary>
         public bool WithMergeRequestsEnabled { get; set; }
+
+        /// <summary>
+        /// Limit by Last Activity After specified datetime
+        /// Note: You would need GitLab 12.10 or later
+        /// </summary>
+        public DateTime LastActivityAfter { get; set; }
+
+        /// <summary>
+        /// Limit by Last Activity Before specified datetime
+        /// Note: You would need GitLab 12.10 or later
+        /// </summary>
+        public DateTime LastActivityBefore { get; set; }
     }
 }


### PR DESCRIPTION
Gitlab introduced last_activity_after and last_activitybefore filters in Project Api in 12.10 release. necessary changes has been done in ProjectQueryBuilder and ProjectQuery Options classes