### PR TITLE
Make querybuilder thread safe

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/BranchQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/BranchQueryBuilder.cs
@@ -1,16 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using GitLabApiClient.Models.Branches.Requests;
 
 namespace GitLabApiClient.Internal.Queries
 {
     internal class BranchQueryBuilder : QueryBuilder<BranchQueryOptions>
     {
-        protected override void BuildCore(BranchQueryOptions options)
+        protected override void BuildCore(Query query, BranchQueryOptions options)
         {
             if (!string.IsNullOrEmpty(options.Search))
-                Add("search", options.Search);
+                query.Add("search", options.Search);
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/CommitQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/CommitQueryBuilder.cs
@@ -9,29 +9,28 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class CommitQueryBuilder : QueryBuilder<CommitQueryOptions>
     {
-        protected override void BuildCore(CommitQueryOptions options)
+        protected override void BuildCore(Query query, CommitQueryOptions options)
         {
             if (!string.IsNullOrEmpty(options.RefName))
-                Add("ref_name", options.RefName);
+                query.Add("ref_name", options.RefName);
 
             if (options.Path.IsNotNullOrEmpty())
-                Add("path", options.Path);
+                query.Add("path", options.Path);
 
             if (options.Since.HasValue)
-                Add("since", options.Since.Value);
+                query.Add("since", options.Since.Value);
 
             if (options.Until.HasValue)
-                Add("until", options.Until.Value);
+                query.Add("until", options.Until.Value);
 
             if (options.All.HasValue)
-                Add("all", options.All.Value);
+                query.Add("all", options.All.Value);
 
             if (options.WithStats.HasValue)
-                Add("with_stats", options.WithStats.Value);
+                query.Add("with_stats", options.WithStats.Value);
 
             if (options.FirstParent.HasValue)
-                Add("first_parent", options.FirstParent.Value);
-
+                query.Add("first_parent", options.FirstParent.Value);
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/CommitRefsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/CommitRefsQueryBuilder.cs
@@ -6,11 +6,11 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class CommitRefsQueryBuilder : QueryBuilder<CommitRefsQueryOptions>
     {
-        protected override void BuildCore(CommitRefsQueryOptions options)
+        protected override void BuildCore(Query query, CommitRefsQueryOptions options)
         {
             if (options.Type != CommitRefType.All)
             {
-                Add("type", options.Type.ToLowerCaseString());
+                query.Add("type", options.Type.ToLowerCaseString());
             }
         }
     }

--- a/src/GitLabApiClient/Internal/Queries/CommitStatusesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/CommitStatusesQueryBuilder.cs
@@ -5,20 +5,19 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class CommitStatusesQueryBuilder : QueryBuilder<CommitStatusesQueryOptions>
     {
-        protected override void BuildCore(CommitStatusesQueryOptions options)
+        protected override void BuildCore(Query query, CommitStatusesQueryOptions options)
         {
             if (!string.IsNullOrEmpty(options.Ref))
-                Add("ref", options.Ref);
+                query.Add("ref", options.Ref);
 
             if (options.Name.IsNotNullOrEmpty())
-                Add("name", options.Name);
+                query.Add("name", options.Name);
 
             if (options.Stage.IsNotNullOrEmpty())
-                Add("stage", options.Stage);
+                query.Add("stage", options.Stage);
 
             if (options.All.HasValue)
-                Add("all", options.All.Value);
-
+                query.Add("all", options.All.Value);
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/GroupLabelsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/GroupLabelsQueryBuilder.cs
@@ -7,16 +7,16 @@ namespace GitLabApiClient.Internal.Queries
         #region Overrides of QueryBuilder<GroupLabelsQueryOptions>
 
         /// <inheritdoc />
-        protected override void BuildCore(GroupLabelsQueryOptions options)
+        protected override void BuildCore(Query query, GroupLabelsQueryOptions options)
         {
             if (options.WithCounts)
             {
-                Add("with_counts", true);
+                query.Add("with_counts", true);
             }
 
             if (!options.IncludeAncestorGroups)
             {
-                Add("include_ancestor_groups", false);
+                query.Add("include_ancestor_groups", false);
             }
         }
 

--- a/src/GitLabApiClient/Internal/Queries/GroupsProjectsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/GroupsProjectsQueryBuilder.cs
@@ -6,53 +6,52 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class ProjectsGroupQueryBuilder : QueryBuilder<ProjectsGroupQueryOptions>
     {
-        protected override void BuildCore(ProjectsGroupQueryOptions options)
+        protected override void BuildCore(Query query, ProjectsGroupQueryOptions options)
         {
             if (options.Archived)
-                Add("archived", options.Archived);
+                query.Add("archived", options.Archived);
 
             if (options.Visibility != GroupsVisibility.Public)
-                Add("visibility", GetVisibilityQueryValue(options.Visibility));
+                query.Add("visibility", GetVisibilityQueryValue(options.Visibility));
 
             if (options.Order != GroupsProjectsOrder.CreatedAt)
-                Add("order_by", GetOrderQueryValue(options.Order));
+                query.Add("order_by", GetOrderQueryValue(options.Order));
 
             if (options.Sort != GroupsSort.Ascending)
-                Add("sort", GetSortQueryValue(options.Sort));
+                query.Add("sort", GetSortQueryValue(options.Sort));
 
             if (!options.Search.IsNullOrEmpty())
-                Add("search", options.Search);
+                query.Add("search", options.Search);
 
             if (options.Simple)
-                Add("simple", options.Simple);
+                query.Add("simple", options.Simple);
 
             if (options.Owned)
-                Add("owned", options.Owned);
+                query.Add("owned", options.Owned);
 
             if (options.Starred)
-                Add("starred", options.Starred);
+                query.Add("starred", options.Starred);
 
             if (options.WithIssuesEnabled)
-                Add("with_issues_enabled", options.WithIssuesEnabled);
+                query.Add("with_issues_enabled", options.WithIssuesEnabled);
 
             if (options.WithMergeRequestsEnabled)
-                Add("with_merge_requests_enabled", options.WithMergeRequestsEnabled);
+                query.Add("with_merge_requests_enabled", options.WithMergeRequestsEnabled);
 
             if (!options.WithShared)
-                Add("with_shared", options.WithShared);
+                query.Add("with_shared", options.WithShared);
 
             if (options.IncludeSubgroups)
-                Add("include_subgroups", options.IncludeSubgroups);
+                query.Add("include_subgroups", options.IncludeSubgroups);
 
             if (options.MinAccessLevel != null)
-                Add("min_access_level", (int)options.MinAccessLevel);
+                query.Add("min_access_level", (int)options.MinAccessLevel);
 
             if (options.WithCustomAttributes)
-                Add("with_custom_attributes", options.WithCustomAttributes);
+                query.Add("with_custom_attributes", options.WithCustomAttributes);
 
             if (options.WithSecurityReports)
-                Add("with_security_reports", options.WithSecurityReports);
-
+                query.Add("with_security_reports", options.WithSecurityReports);
         }
 
         private static string GetVisibilityQueryValue(GroupsVisibility visibility)

--- a/src/GitLabApiClient/Internal/Queries/GroupsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/GroupsQueryBuilder.cs
@@ -6,33 +6,33 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class GroupsQueryBuilder : QueryBuilder<GroupsQueryOptions>
     {
-        protected override void BuildCore(GroupsQueryOptions options)
+        protected override void BuildCore(Query query, GroupsQueryOptions options)
         {
-            Add("skip_groups", options.SkipGroups);
+            query.Add("skip_groups", options.SkipGroups);
 
             if (options.AllAvailable)
-                Add("all_available", options.AllAvailable);
+                query.Add("all_available", options.AllAvailable);
 
             if (!options.Search.IsNullOrEmpty())
-                Add("search", options.Search);
+                query.Add("search", options.Search);
 
             if (options.Order != GroupsOrder.Name)
-                Add("order_by", GetOrderQueryValue(options.Order));
+                query.Add("order_by", GetOrderQueryValue(options.Order));
 
             if (options.Sort != GroupsSort.Ascending)
-                Add("sort", GetSortQueryValue(options.Sort));
+                query.Add("sort", GetSortQueryValue(options.Sort));
 
             if (options.Statistics)
-                Add("statistics", options.Statistics);
+                query.Add("statistics", options.Statistics);
 
             if (options.WithCustomAttributes)
-                Add("with_custom_attributes", options.WithCustomAttributes);
+                query.Add("with_custom_attributes", options.WithCustomAttributes);
 
             if (options.Owned)
-                Add("owned", options.Owned);
+                query.Add("owned", options.Owned);
 
             if (options.MinAccessLevel.HasValue)
-                Add("min_access_level", (int)options.MinAccessLevel.Value);
+                query.Add("min_access_level", (int)options.MinAccessLevel.Value);
         }
 
         private static string GetOrderQueryValue(GroupsOrder order)

--- a/src/GitLabApiClient/Internal/Queries/IssuesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/IssuesQueryBuilder.cs
@@ -9,55 +9,55 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class IssuesQueryBuilder : QueryBuilder<IssuesQueryOptions>
     {
-        protected override void BuildCore(IssuesQueryOptions options)
+        protected override void BuildCore(Query query, IssuesQueryOptions options)
         {
             string stateQueryValue = GetStateQueryValue(options.State);
             if (!stateQueryValue.IsNullOrEmpty())
-                Add("state", stateQueryValue);
+                query.Add("state", stateQueryValue);
 
             if (options.Labels.Any())
-                Add("labels", options.Labels);
+                query.Add("labels", options.Labels);
 
             if (!options.MilestoneTitle.IsNullOrEmpty())
-                Add("milestone", options.MilestoneTitle);
+                query.Add("milestone", options.MilestoneTitle);
 
-            Add("scope", GetScopeQueryValue(options.Scope));
+            query.Add("scope", GetScopeQueryValue(options.Scope));
 
             if (options.AuthorId.HasValue)
-                Add("author_id", options.AuthorId.Value);
+                query.Add("author_id", options.AuthorId.Value);
             else if (!string.IsNullOrWhiteSpace(options.AuthorUsername))
-                Add("author_username", options.AuthorUsername);
+                query.Add("author_username", options.AuthorUsername);
 
             if (options.AssigneeId.HasValue)
-                Add("assignee_id", options.AssigneeId.Value);
+                query.Add("assignee_id", options.AssigneeId.Value);
             else if (options.AssigneeUsername.Any())
-                Add("assignee_username", options.AssigneeUsername);
+                query.Add("assignee_username", options.AssigneeUsername);
 
-            Add(options.IssueIds);
+            query.Add(options.IssueIds);
 
             if (options.Order != IssuesOrder.CreatedAt)
-                Add("order_by", GetIssuesOrderQueryValue(options.Order));
+                query.Add("order_by", GetIssuesOrderQueryValue(options.Order));
 
             if (options.SortOrder != SortOrder.Descending)
-                Add("sort", GetSortOrderQueryValue(options.SortOrder));
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
 
             if (!options.Filter.IsNullOrEmpty())
-                Add("search", options.Filter);
+                query.Add("search", options.Filter);
 
             if (options.IsConfidential)
-                Add("confidential", true);
+                query.Add("confidential", true);
 
             if (options.CreatedBefore.HasValue)
-                Add("created_before", options.CreatedBefore.Value);
+                query.Add("created_before", options.CreatedBefore.Value);
 
             if (options.CreatedAfter.HasValue)
-                Add("created_after", options.CreatedAfter.Value);
+                query.Add("created_after", options.CreatedAfter.Value);
 
             if (options.UpdatedBefore.HasValue)
-                Add("updated_before", options.UpdatedBefore.Value);
+                query.Add("updated_before", options.UpdatedBefore.Value);
 
             if (options.UpdatedAfter.HasValue)
-                Add("updated_after", options.UpdatedAfter.Value);
+                query.Add("updated_after", options.UpdatedAfter.Value);
         }
 
         private static string GetStateQueryValue(IssueState state)

--- a/src/GitLabApiClient/Internal/Queries/JobQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/JobQueryBuilder.cs
@@ -1,19 +1,18 @@
-using System;
-using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models.Job.Requests;
 
-namespace GitLabApiClient.Models.Job.Requests
+namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class JobQueryBuilder : QueryBuilder<JobQueryOptions>
     {
         #region Overrides of QueryBuilder<PipelineQueryOptions>
 
         /// <inheritdoc />
-        protected override void BuildCore(JobQueryOptions options)
+        protected override void BuildCore(Query query, JobQueryOptions options)
         {
             if (options.Scope != JobScope.All)
             {
-                Add("scope", options.Scope.ToLowerCaseString());
+                query.Add("scope", options.Scope.ToLowerCaseString());
             }
         }
 

--- a/src/GitLabApiClient/Internal/Queries/MergeRequestsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/MergeRequestsQueryBuilder.cs
@@ -8,40 +8,40 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class MergeRequestsQueryBuilder : QueryBuilder<MergeRequestsQueryOptions>
     {
-        protected override void BuildCore(MergeRequestsQueryOptions options)
+        protected override void BuildCore(Query query, MergeRequestsQueryOptions options)
         {
             string stateQueryValue = GetStateQueryValue(options.State);
             if (!stateQueryValue.IsNullOrEmpty())
-                Add("state", stateQueryValue);
+                query.Add("state", stateQueryValue);
 
             if (options.Order != MergeRequestsOrder.CreatedAt)
-                Add("order_by", GetIssuesOrderQueryValue(options.Order));
+                query.Add("order_by", GetIssuesOrderQueryValue(options.Order));
 
             if (options.SortOrder != SortOrder.Descending)
-                Add("sort", GetSortOrderQueryValue(options.SortOrder));
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
 
             if (!options.MilestoneTitle.IsNullOrEmpty())
-                Add("milestone", options.MilestoneTitle);
+                query.Add("milestone", options.MilestoneTitle);
 
             if (options.Simple)
-                Add("view", "simple");
+                query.Add("view", "simple");
 
             if (options.Labels.Any())
-                Add("labels", options.Labels);
+                query.Add("labels", options.Labels);
 
             if (options.CreatedAfter.HasValue)
-                Add("created_after", options.CreatedAfter.Value);
+                query.Add("created_after", options.CreatedAfter.Value);
 
             if (options.CreatedBefore.HasValue)
-                Add("created_before", options.CreatedBefore.Value);
+                query.Add("created_before", options.CreatedBefore.Value);
 
-            Add("scope", GetScopeQueryValue(options.Scope));
+            query.Add("scope", GetScopeQueryValue(options.Scope));
 
             if (options.AuthorId.HasValue)
-                Add("author_id", options.AuthorId.Value);
+                query.Add("author_id", options.AuthorId.Value);
 
             if (options.AssigneeId.HasValue)
-                Add("assignee_id", options.AssigneeId.Value);
+                query.Add("assignee_id", options.AssigneeId.Value);
         }
 
         private static string GetStateQueryValue(QueryMergeRequestState state)

--- a/src/GitLabApiClient/Internal/Queries/MilestonesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/MilestonesQueryBuilder.cs
@@ -6,17 +6,17 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class MilestonesQueryBuilder : QueryBuilder<MilestonesQueryOptions>
     {
-        protected override void BuildCore(MilestonesQueryOptions options)
+        protected override void BuildCore(Query query, MilestonesQueryOptions options)
         {
             if (options.MilestoneIds.Count > 0)
-                Add(options.MilestoneIds);
+                query.Add(options.MilestoneIds);
 
             string stateQueryValue = GetStateQueryValue(options.State);
             if (!string.IsNullOrEmpty(stateQueryValue))
-                Add("state", stateQueryValue);
+                query.Add("state", stateQueryValue);
 
             if (!string.IsNullOrEmpty(options.Search))
-                Add("search", options.Search);
+                query.Add("search", options.Search);
         }
 
         private static string GetStateQueryValue(MilestoneState state)

--- a/src/GitLabApiClient/Internal/Queries/PipelineQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/PipelineQueryBuilder.cs
@@ -1,64 +1,66 @@
 using System;
-using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models;
+using GitLabApiClient.Models.Pipelines;
+using GitLabApiClient.Models.Pipelines.Requests;
 
-namespace GitLabApiClient.Models.Pipelines.Requests
+namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class PipelineQueryBuilder : QueryBuilder<PipelineQueryOptions>
     {
         #region Overrides of QueryBuilder<PipelineQueryOptions>
 
         /// <inheritdoc />
-        protected override void BuildCore(PipelineQueryOptions options)
+        protected override void BuildCore(Query query, PipelineQueryOptions options)
         {
             if (!options.Ref.IsNullOrEmpty())
             {
-                Add("ref", options.Ref);
+                query.Add("ref", options.Ref);
             }
 
             if (options.YamlErrors.HasValue)
             {
-                Add("yaml_errors", options.YamlErrors.Value);
+                query.Add("yaml_errors", options.YamlErrors.Value);
             }
 
             if (!options.Sha.IsNullOrEmpty())
             {
-                Add("sha", options.Sha);
+                query.Add("sha", options.Sha);
             }
 
             if (options.Status != PipelineStatus.All)
             {
-                Add("status", options.Status.ToLowerCaseString());
+                query.Add("status", options.Status.ToLowerCaseString());
             }
 
             if (options.Scope != PipelineScope.All)
             {
-                Add("scope", options.Scope.ToLowerCaseString());
+                query.Add("scope", options.Scope.ToLowerCaseString());
             }
 
             if (options.Order != PipelineOrder.Id)
             {
-                Add("order_by", AsString(options.Order));
+                query.Add("order_by", AsString(options.Order));
             }
 
             if (options.SortOrder != SortOrder.Descending)
             {
-                Add("sort", "asc");
+                query.Add("sort", "asc");
             }
 
             if (options.UpdatedAfter.HasValue)
             {
-                Add("updated_after", options.UpdatedAfter.Value);
+                query.Add("updated_after", options.UpdatedAfter.Value);
             }
 
             if (options.UpdatedBefore.HasValue)
             {
-                Add("updated_before", options.UpdatedBefore.Value);
+                query.Add("updated_before", options.UpdatedBefore.Value);
             }
 
             if (!options.TriggeredBy.IsNullOrEmpty())
             {
-                Add("username", options.TriggeredBy);
+                query.Add("username", options.TriggeredBy);
             }
         }
 

--- a/src/GitLabApiClient/Internal/Queries/ProjectIssueNotesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectIssueNotesQueryBuilder.cs
@@ -6,13 +6,13 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class ProjectIssueNotesQueryBuilder : QueryBuilder<IssueNotesQueryOptions>
     {
-        protected override void BuildCore(IssueNotesQueryOptions options)
+        protected override void BuildCore(Query query, IssueNotesQueryOptions options)
         {
             if (options.SortOrder != SortOrder.Descending)
-                Add("sort", GetSortOrderQueryValue(options.SortOrder));
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
 
             if (options.Order != NoteOrder.CreatedAt)
-                Add("order_by", GetNoteOrderQueryValue(options.Order));
+                query.Add("order_by", GetNoteOrderQueryValue(options.Order));
         }
 
         private static string GetNoteOrderQueryValue(NoteOrder order)

--- a/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsNotesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsNotesQueryBuilder.cs
@@ -6,13 +6,13 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class ProjectMergeRequestsNotesQueryBuilder : QueryBuilder<MergeRequestNotesQueryOptions>
     {
-        protected override void BuildCore(MergeRequestNotesQueryOptions options)
+        protected override void BuildCore(Query query, MergeRequestNotesQueryOptions options)
         {
             if (options.SortOrder != SortOrder.Descending)
-                Add("sort", GetSortOrderQueryValue(options.SortOrder));
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
 
             if (options.Order != NoteOrder.CreatedAt)
-                Add("order_by", GetNoteOrderQueryValue(options.Order));
+                query.Add("order_by", GetNoteOrderQueryValue(options.Order));
         }
 
         private static string GetNoteOrderQueryValue(NoteOrder order)

--- a/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectMergeRequestsQueryBuilder.cs
@@ -4,16 +4,16 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class ProjectMergeRequestsQueryBuilder : MergeRequestsQueryBuilder
     {
-        protected override void BuildCore(MergeRequestsQueryOptions options)
+        protected override void BuildCore(Query query, MergeRequestsQueryOptions options)
         {
             if (!(options is ProjectMergeRequestsQueryOptions projectOptions))
             {
-                base.BuildCore(options);
+                base.BuildCore(query, options);
                 return;
             }
 
-            Add(projectOptions.MergeRequestsIds);
-            base.BuildCore(options);
+            query.Add(projectOptions.MergeRequestsIds);
+            base.BuildCore(query, options);
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/ProjectsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ProjectsQueryBuilder.cs
@@ -7,46 +7,46 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class ProjectsQueryBuilder : QueryBuilder<ProjectQueryOptions>
     {
-        protected override void BuildCore(ProjectQueryOptions options)
+        protected override void BuildCore(Query query, ProjectQueryOptions options)
         {
             if (!options.UserId.IsNullOrEmpty())
-                Add("user_id", options.UserId);
+                query.Add("user_id", options.UserId);
 
             if (options.Archived)
-                Add("archived", options.Archived);
+                query.Add("archived", options.Archived);
 
             if (options.Visibility != QueryProjectVisibilityLevel.All)
-                Add("visibility", GetVisibilityQueryValue(options.Visibility));
+                query.Add("visibility", GetVisibilityQueryValue(options.Visibility));
 
             if (options.Order != ProjectsOrder.CreatedAt)
-                Add("order_by", GetProjectOrderQueryValue(options.Order));
+                query.Add("order_by", GetProjectOrderQueryValue(options.Order));
 
             if (options.SortOrder != SortOrder.Descending)
-                Add("sort", GetSortOrderQueryValue(options.SortOrder));
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
 
             if (!options.Filter.IsNullOrEmpty())
-                Add("search", options.Filter);
+                query.Add("search", options.Filter);
 
             if (options.Simple)
-                Add("simple", options.Simple);
+                query.Add("simple", options.Simple);
 
             if (options.Owned)
-                Add("owned", options.Owned);
+                query.Add("owned", options.Owned);
 
             if (options.IsMemberOf)
-                Add("membership", options.IsMemberOf);
+                query.Add("membership", options.IsMemberOf);
 
             if (options.Starred)
-                Add("starred", options.Starred);
+                query.Add("starred", options.Starred);
 
             if (options.IncludeStatistics)
-                Add("statistics", options.IncludeStatistics);
+                query.Add("statistics", options.IncludeStatistics);
 
             if (options.WithIssuesEnabled)
-                Add("with_issues_enabled", options.WithIssuesEnabled);
+                query.Add("with_issues_enabled", options.WithIssuesEnabled);
 
             if (options.WithMergeRequestsEnabled)
-                Add("with_merge_requests_enabled", options.WithMergeRequestsEnabled);
+                query.Add("with_merge_requests_enabled", options.WithMergeRequestsEnabled);
         }
 
         private static string GetProjectOrderQueryValue(ProjectsOrder order)

--- a/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
@@ -7,7 +7,7 @@ namespace GitLabApiClient.Internal.Queries
 {
     class ReleaseQueryBuilder : QueryBuilder<ReleaseQueryOptions>
     {
-        protected override void BuildCore(ReleaseQueryOptions options)
+        protected override void BuildCore(Query query, ReleaseQueryOptions options)
         {
         }
     }

--- a/src/GitLabApiClient/Internal/Queries/TagQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/TagQueryBuilder.cs
@@ -7,13 +7,13 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class TagQueryBuilder : QueryBuilder<TagQueryOptions>
     {
-        protected override void BuildCore(TagQueryOptions options)
+        protected override void BuildCore(Query query, TagQueryOptions options)
         {
             if (!string.IsNullOrEmpty(options.Search))
-                Add("search", options.Search);
+                query.Add("search", options.Search);
 
-            Add("order_by", options.OrderBy.ToString().ToLower());
-            Add("sort", options.Sort.ToString().ToLower());
+            query.Add("order_by", options.OrderBy.ToString().ToLower());
+            query.Add("sort", options.Sort.ToString().ToLower());
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/ToDoListQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ToDoListQueryBuilder.cs
@@ -6,25 +6,25 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal sealed class ToDoListQueryBuilder : QueryBuilder<ToDoListQueryOptions>
     {
-        protected override void BuildCore(ToDoListQueryOptions options)
+        protected override void BuildCore(Query query, ToDoListQueryOptions options)
         {
             if (options.ActionType != null)
-                Add("action", options.ActionType.GetAttribute<EnumMemberAttribute>().Value);
+                query.Add("action", options.ActionType.GetAttribute<EnumMemberAttribute>().Value);
 
             if (options.AuthorId.HasValue)
-                Add("author_id", options.AuthorId.Value);
+                query.Add("author_id", options.AuthorId.Value);
 
             if (options.ProjectId.HasValue)
-                Add("project_id", options.ProjectId.Value);
+                query.Add("project_id", options.ProjectId.Value);
 
             if (options.GroupId.HasValue)
-                Add("group_id", options.GroupId.Value);
+                query.Add("group_id", options.GroupId.Value);
 
             if (options.State != null)
-                Add("state", options.State.GetAttribute<EnumMemberAttribute>().Value);
+                query.Add("state", options.State.GetAttribute<EnumMemberAttribute>().Value);
 
             if (options.Type != null)
-                Add("type", options.Type.GetAttribute<EnumMemberAttribute>().Value);
+                query.Add("type", options.Type.GetAttribute<EnumMemberAttribute>().Value);
         }
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/TreeQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/TreeQueryBuilder.cs
@@ -8,17 +8,16 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal class TreeQueryBuilder : QueryBuilder<TreeQueryOptions>
     {
-        protected override void BuildCore(TreeQueryOptions options)
+        protected override void BuildCore(Query query, TreeQueryOptions options)
         {
             if (!string.IsNullOrEmpty(options.Reference))
-                Add("ref", options.Reference);
+                query.Add("ref", options.Reference);
 
             if (!string.IsNullOrEmpty(options.Path))
-                Add("path", options.Path);
+                query.Add("path", options.Path);
 
             if (options.Recursive)
-                Add("recursive", options.Recursive);
-
+                query.Add("recursive", options.Recursive);
         }
     }
 }

--- a/src/GitLabApiClient/PipelineClient.cs
+++ b/src/GitLabApiClient/PipelineClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Models.Job.Requests;
 using GitLabApiClient.Models.Job.Responses;
 using GitLabApiClient.Models.Pipelines.Requests;

--- a/test/GitLabApiClient.Test/Internal/Queries/PipelineQueryBuilderTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Queries/PipelineQueryBuilderTest.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Models;
 using GitLabApiClient.Models.Pipelines;
 using GitLabApiClient.Models.Pipelines.Requests;


### PR DESCRIPTION
Hi,

At `thetradedesk` we have been using a fork of this project for over a year now, and one of the foundational changes we made was to introduce thread safety to the query builders in the API client. We found that this was the only part of the code base that wasn't compatible with concurrent callers of the same client.

There are 2 new object allocations per request (a new NameValueCollection, and the wrapping Query object). This change makes the singleton querybuilders thread safe, as each request gets it own query object.

Please let me know any thoughts. Since the development of this library has picked up in the past 12 months, we hope to slowly contribute out changes back upstream, for the benefit of all, and so that we do not need to maintain our own fork.

fixes #104