### PR TITLE
Add Group Variables CRUD methods

### DIFF
--- a/src/GitLabApiClient/GroupsClient.cs
+++ b/src/GitLabApiClient/GroupsClient.cs
@@ -336,5 +336,44 @@ namespace GitLabApiClient
         /// <param name="name">Name of the label.</param>
         public async Task DeleteLabelAsync(GroupId groupId, string name) =>
             await _httpFacade.Delete($"groups/{groupId}/labels?name={name}");
+
+        /// <summary>
+        /// Retrieves group variables by its id.
+        /// </summary>
+        /// <param name="groupId">Id of the group.</param>
+        public async Task<IList<Variable>> GetVariablesAsync(GroupId groupId) =>
+            await _httpFacade.GetPagedList<Variable>($"groups/{groupId}/variables");
+
+        /// <summary>
+        /// Creates new project variable.
+        /// </summary>
+        /// <param name="groupId">The ID, path or <see cref="Group"/> of the group.</param>
+        /// <param name="request">Create variable request.</param>
+        /// <returns>Newly created variable.</returns>
+        public async Task<Variable> CreateVariableAsync(GroupId groupId, CreateGroupVariableRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+            return await _httpFacade.Post<Variable>($"groups/{groupId}/variables", request);
+        }
+
+        /// <summary>
+        /// Updates an existing group variable.
+        /// </summary>
+        /// <param name="groupId">The ID, path or <see cref="Group"/> of the group.</param>
+        /// <param name="request">Update variable request.</param>
+        /// <returns>Newly modified variable.</returns>
+        public async Task<Variable> UpdateVariableAsync(GroupId groupId, UpdateGroupVariableRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+            return await _httpFacade.Put<Variable>($"groups/{groupId}/variables/{request.Key}", request);
+        }
+
+        /// <summary>
+        /// Deletes group variable
+        /// </summary>
+        /// <param name="groupId">The ID, path or <see cref="Group"/> of the group.</param>
+        /// <param name="key">The Key ID of the variable.</param>
+        public async Task DeleteVariableAsync(GroupId groupId, string key) =>
+            await _httpFacade.Delete($"groups/{groupId}/variables/{key}");
     }
 }

--- a/src/GitLabApiClient/Models/Groups/Requests/CreateGroupVariableRequest.cs
+++ b/src/GitLabApiClient/Models/Groups/Requests/CreateGroupVariableRequest.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Groups.Requests
+{
+    public class CreateGroupVariableRequest
+    {
+        /// <summary>
+        /// The type of a variable.
+        /// Available types are: env_var (default) and file
+        /// </summary>
+        [JsonProperty("variable_type")]
+        public string VariableType { get; set; }
+
+        /// <summary>
+        /// The key of a variable
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        /// <summary>
+        /// The value of a variable
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Whether the variable is protected
+        /// </summary>
+        [JsonProperty("protected")]
+        public bool? Protected { get; set; }
+
+        /// <summary>
+        /// Whether the variable is masked
+        /// </summary>
+        [JsonProperty("masked")]
+        public bool? Masked { get; set; }
+    }
+}

--- a/src/GitLabApiClient/Models/Groups/Requests/UpdateGroupVariableRequest.cs
+++ b/src/GitLabApiClient/Models/Groups/Requests/UpdateGroupVariableRequest.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Groups.Requests
+{
+    public class UpdateGroupVariableRequest
+    {
+        /// <summary>
+        /// The type of a variable.
+        /// Available types are: env_var (default) and file
+        /// </summary>
+        [JsonProperty("variable_type")]
+        public string VariableType { get; set; }
+
+        /// <summary>
+        /// The key of a variable
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        /// <summary>
+        /// The value of a variable
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Whether the variable is protected
+        /// </summary>
+        [JsonProperty("protected")]
+        public bool? Protected { get; set; }
+
+        /// <summary>
+        /// Whether the variable is masked
+        /// </summary>
+        [JsonProperty("masked")]
+        public bool? Masked { get; set; }
+    }
+}

--- a/src/GitLabApiClient/Models/Groups/Responses/Variable.cs
+++ b/src/GitLabApiClient/Models/Groups/Responses/Variable.cs
@@ -1,0 +1,38 @@
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Groups.Responses
+{
+    public sealed class Variable
+    {
+        /// <summary>
+        /// The type of a variable.
+        /// Available types are: env_var (default) and file
+        /// </summary>
+        [JsonProperty("variable_type")]
+        public string VariableType { get; set; }
+
+        /// <summary>
+        /// The key of a variable
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        /// <summary>
+        /// The value of a variable
+        /// </summary>
+        [JsonProperty("value")]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// Whether the variable is protected
+        /// </summary>
+        [JsonProperty("protected")]
+        public bool Protected { get; set; }
+
+        /// <summary>
+        /// Whether the variable is masked
+        /// </summary>
+        [JsonProperty("masked")]
+        public bool Masked { get; set; }
+    }
+}

--- a/src/GitLabApiClient/ProjectsClient.cs
+++ b/src/GitLabApiClient/ProjectsClient.cs
@@ -71,7 +71,7 @@ namespace GitLabApiClient
         /// Retrieves project variables by its id.
         /// </summary>
         /// <param name="projectId">Id of the project.</param>
-        public async Task<IList<Variable>> GetVariablesAsync(int projectId) =>
+        public async Task<IList<Variable>> GetVariablesAsync(ProjectId projectId) =>
             await _httpFacade.GetPagedList<Variable>($"projects/{projectId}/variables");
 
         /// <summary>

--- a/test/GitLabApiClient.Test/GitLabClientTest.cs
+++ b/test/GitLabApiClient.Test/GitLabClientTest.cs
@@ -66,7 +66,7 @@ namespace GitLabApiClient.Test
                 accessTokenResponse.CreatedAt.Should().NotBeNull();
                 accessTokenResponse.AccessToken.Should().HaveLength(64);
                 accessTokenResponse.RefreshToken.Should().HaveLength(64);
-                accessTokenResponse.TokenType.Should().Be("bearer");
+                accessTokenResponse.TokenType.Should().BeEquivalentTo("bearer");
                 var currentSessionAsync = await sut.Users.GetCurrentSessionAsync();
                 currentSessionAsync.Username.Should().Be(GitLabApiHelper.TestUserName);
 

--- a/test/GitLabApiClient.Test/Utilities/GitLabContainerFixture.cs
+++ b/test/GitLabApiClient.Test/Utilities/GitLabContainerFixture.cs
@@ -21,7 +21,7 @@ namespace GitLabApiClient.Test.Utilities
         public static string GitlabHost { get; private set; }
 
         private IContainerService _gitlabContainer;
-        private readonly string _gitlabDockerImage = "gitlab/gitlab-ce:12.5.4-ce.0";
+        private readonly string _gitlabDockerImage = "gitlab/gitlab-ce:12.10.2-ce.0";
 
         public async Task InitializeAsync()
         {


### PR DESCRIPTION
This PR adds support for interacting with group-level variables.

I wasn't sure whether I should add the group variable types to the Variables folder or stick them into the Groups folder, so I opted for the latter. But I'm happy to move them to the Variables folder if that has preference. If so, I suggest that we rename `Variable` to `ProjectVariable` to make a clear distinction between the two types of variables, and propagate this change wherever applicable. I'm also happy to move the stuff from Variables into the Projects folder.

Either way, it will be more consistent. Just say the word.