### PR TITLE
close #104

### DIFF
--- a/src/GitLabApiClient/BranchClient.cs
+++ b/src/GitLabApiClient/BranchClient.cs
@@ -13,15 +13,8 @@ namespace GitLabApiClient
     public sealed class BranchClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly BranchQueryBuilder _branchQueryBuilder;
 
-        internal BranchClient(
-            GitLabHttpFacade httpFacade,
-            BranchQueryBuilder branchQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _branchQueryBuilder = branchQueryBuilder;
-        }
+        internal BranchClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves a single branch
@@ -43,7 +36,7 @@ namespace GitLabApiClient
             var queryOptions = new BranchQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _branchQueryBuilder.Build($"projects/{projectId}/repository/branches", queryOptions);
+            string url = new BranchQueryBuilder().Build($"projects/{projectId}/repository/branches", queryOptions);
             return await _httpFacade.GetPagedList<Branch>(url);
         }
 

--- a/src/GitLabApiClient/CommitsClient.cs
+++ b/src/GitLabApiClient/CommitsClient.cs
@@ -13,17 +13,8 @@ namespace GitLabApiClient
     public sealed class CommitsClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly CommitQueryBuilder _commitQueryBuilder;
-        private readonly CommitRefsQueryBuilder _commitRefsQueryBuilder;
-        private readonly CommitStatusesQueryBuilder _commitStatusesQueryBuilder;
 
-        internal CommitsClient(GitLabHttpFacade httpFacade, CommitQueryBuilder commitQueryBuilder, CommitRefsQueryBuilder commitRefsQueryBuilder, CommitStatusesQueryBuilder commitStatusesQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _commitQueryBuilder = commitQueryBuilder;
-            _commitRefsQueryBuilder = commitRefsQueryBuilder;
-            _commitStatusesQueryBuilder = commitStatusesQueryBuilder;
-        }
+        internal CommitsClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Get a commit from commit sha
@@ -45,7 +36,7 @@ namespace GitLabApiClient
             var queryOptions = new CommitQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _commitQueryBuilder.Build($"projects/{projectId}/repository/commits", queryOptions);
+            string url = new CommitQueryBuilder().Build($"projects/{projectId}/repository/commits", queryOptions);
             return await _httpFacade.GetPagedList<Commit>(url);
         }
 
@@ -61,7 +52,7 @@ namespace GitLabApiClient
             var queryOptions = new CommitRefsQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _commitRefsQueryBuilder.Build($"projects/{projectId}/repository/commits/{sha}/refs", queryOptions);
+            string url = new CommitRefsQueryBuilder().Build($"projects/{projectId}/repository/commits/{sha}/refs", queryOptions);
             return await _httpFacade.GetPagedList<CommitRef>(url);
         }
 
@@ -89,7 +80,7 @@ namespace GitLabApiClient
             var queryOptions = new CommitStatusesQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _commitStatusesQueryBuilder.Build($"projects/{projectId}/repository/commits/{sha}/statuses", queryOptions);
+            string url = new CommitStatusesQueryBuilder().Build($"projects/{projectId}/repository/commits/{sha}/statuses", queryOptions);
             return await _httpFacade.GetPagedList<CommitStatuses>(url);
         }
     }

--- a/src/GitLabApiClient/GitLabClient.cs
+++ b/src/GitLabApiClient/GitLabClient.cs
@@ -2,12 +2,9 @@ using System;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Http.Serialization;
-using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Internal.Utilities;
-using GitLabApiClient.Models.Job.Requests;
 using GitLabApiClient.Models.Oauth.Requests;
 using GitLabApiClient.Models.Oauth.Responses;
-using GitLabApiClient.Models.Pipelines.Requests;
 
 namespace GitLabApiClient
 {
@@ -36,44 +33,23 @@ namespace GitLabApiClient
                 jsonSerializer,
                 authenticationToken);
 
-            var projectQueryBuilder = new ProjectsQueryBuilder();
-            var projectIssueNotesQueryBuilder = new ProjectIssueNotesQueryBuilder();
-            var projectMergeRequestsNotesQueryBuilder = new ProjectMergeRequestsNotesQueryBuilder();
-            var issuesQueryBuilder = new IssuesQueryBuilder();
-            var mergeRequestsQueryBuilder = new MergeRequestsQueryBuilder();
-            var projectMilestonesQueryBuilder = new MilestonesQueryBuilder();
-            var projectMergeRequestsQueryBuilder = new ProjectMergeRequestsQueryBuilder();
-            var groupsQueryBuilder = new GroupsQueryBuilder();
-            var groupLabelsQueryBuilder = new GroupLabelsQueryBuilder();
-            var projectsGroupsQueryBuilder = new ProjectsGroupQueryBuilder();
-            var branchQueryBuilder = new BranchQueryBuilder();
-            var releaseQueryBuilder = new ReleaseQueryBuilder();
-            var tagQueryBuilder = new TagQueryBuilder();
-            var commitQueryBuilder = new CommitQueryBuilder();
-            var commitRefsQueryBuilder = new CommitRefsQueryBuilder();
-            var commitStatusesQueryBuilder = new CommitStatusesQueryBuilder();
-            var pipelineQueryBuilder = new PipelineQueryBuilder();
-            var treeQueryBuilder = new TreeQueryBuilder();
-            var jobQueryBuilder = new JobQueryBuilder();
-            var toDoListBuilder = new ToDoListQueryBuilder();
-
-            Issues = new IssuesClient(_httpFacade, issuesQueryBuilder, projectIssueNotesQueryBuilder);
+            Issues = new IssuesClient(_httpFacade);
             Uploads = new UploadsClient(_httpFacade);
-            MergeRequests = new MergeRequestsClient(_httpFacade, mergeRequestsQueryBuilder, projectMergeRequestsQueryBuilder, projectMergeRequestsNotesQueryBuilder);
-            Projects = new ProjectsClient(_httpFacade, projectQueryBuilder, projectMilestonesQueryBuilder, jobQueryBuilder);
+            MergeRequests = new MergeRequestsClient(_httpFacade);
+            Projects = new ProjectsClient(_httpFacade);
             Users = new UsersClient(_httpFacade);
-            Groups = new GroupsClient(_httpFacade, groupsQueryBuilder, projectsGroupsQueryBuilder, projectMilestonesQueryBuilder, groupLabelsQueryBuilder);
-            Branches = new BranchClient(_httpFacade, branchQueryBuilder);
-            Releases = new ReleaseClient(_httpFacade, releaseQueryBuilder);
-            Tags = new TagClient(_httpFacade, tagQueryBuilder);
+            Groups = new GroupsClient(_httpFacade);
+            Branches = new BranchClient(_httpFacade);
+            Releases = new ReleaseClient(_httpFacade);
+            Tags = new TagClient(_httpFacade);
             Webhooks = new WebhookClient(_httpFacade);
-            Commits = new CommitsClient(_httpFacade, commitQueryBuilder, commitRefsQueryBuilder, commitStatusesQueryBuilder);
+            Commits = new CommitsClient(_httpFacade);
             Markdown = new MarkdownClient(_httpFacade);
-            Pipelines = new PipelineClient(_httpFacade, pipelineQueryBuilder, jobQueryBuilder);
-            Trees = new TreesClient(_httpFacade, treeQueryBuilder);
+            Pipelines = new PipelineClient(_httpFacade);
+            Trees = new TreesClient(_httpFacade);
             Files = new FilesClient(_httpFacade);
             Runners = new RunnersClient(_httpFacade);
-            ToDoList = new ToDoListClient(_httpFacade, toDoListBuilder);
+            ToDoList = new ToDoListClient(_httpFacade);
         }
 
         /// <summary>

--- a/src/GitLabApiClient/GroupsClient.cs
+++ b/src/GitLabApiClient/GroupsClient.cs
@@ -23,24 +23,8 @@ namespace GitLabApiClient
     public sealed class GroupsClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly GroupsQueryBuilder _queryBuilder;
-        private readonly ProjectsGroupQueryBuilder _projectsQueryBuilder;
-        private readonly MilestonesQueryBuilder _queryMilestonesBuilder;
-        private readonly GroupLabelsQueryBuilder _queryGroupLabelBuilder;
 
-        internal GroupsClient(
-            GitLabHttpFacade httpFacade,
-            GroupsQueryBuilder queryBuilder,
-            ProjectsGroupQueryBuilder projectsQueryBuilder,
-            MilestonesQueryBuilder queryMilestonesBuilder,
-            GroupLabelsQueryBuilder queryGroupLabelBuilder)
-        {
-            _httpFacade = httpFacade;
-            _queryBuilder = queryBuilder;
-            _projectsQueryBuilder = projectsQueryBuilder;
-            _queryMilestonesBuilder = queryMilestonesBuilder;
-            _queryGroupLabelBuilder = queryGroupLabelBuilder;
-        }
+        internal GroupsClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Get all details of a group.
@@ -75,7 +59,7 @@ namespace GitLabApiClient
             var queryOptions = new GroupsQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryBuilder.Build("groups", queryOptions);
+            string url = new GroupsQueryBuilder().Build("groups", queryOptions);
             return await _httpFacade.GetPagedList<Group>(url);
         }
 
@@ -91,7 +75,7 @@ namespace GitLabApiClient
             var queryOptions = new ProjectsGroupQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _projectsQueryBuilder.Build($"groups/{groupId}/projects", queryOptions);
+            string url = new ProjectsGroupQueryBuilder().Build($"groups/{groupId}/projects", queryOptions);
             return await _httpFacade.GetPagedList<Project>(url);
         }
 
@@ -153,7 +137,7 @@ namespace GitLabApiClient
             var queryOptions = new MilestonesQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryMilestonesBuilder.Build($"groups/{groupId}/milestones", queryOptions);
+            string url = new MilestonesQueryBuilder().Build($"groups/{groupId}/milestones", queryOptions);
             return await _httpFacade.GetPagedList<Milestone>(url);
         }
 
@@ -301,7 +285,7 @@ namespace GitLabApiClient
             var labelOptions = new GroupLabelsQueryOptions();
             options?.Invoke(labelOptions);
 
-            string url = _queryGroupLabelBuilder.Build($"groups/{groupId}/labels", labelOptions);
+            string url = new GroupLabelsQueryBuilder().Build($"groups/{groupId}/labels", labelOptions);
             return await _httpFacade.GetPagedList<GroupLabel>(url);
         }
 

--- a/src/GitLabApiClient/Internal/Queries/QueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/QueryBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using GitLabApiClient.Internal.Utilities;
 using GitLabApiClient.Models;
@@ -9,11 +8,10 @@ namespace GitLabApiClient.Internal.Queries
 {
     internal abstract class QueryBuilder<T>
     {
-        private readonly NameValueCollection _nameValues = new NameValueCollection();
+        private readonly List<string> _nameValues = new List<string>();
 
         public string Build(string baseUrl, T options)
         {
-            _nameValues.Clear();
             BuildCore(options);
             return baseUrl + ToQueryString(_nameValues);
         }
@@ -21,7 +19,7 @@ namespace GitLabApiClient.Internal.Queries
         protected abstract void BuildCore(T options);
 
         protected void Add(string name, string value)
-            => _nameValues.Add(name, value);
+            => _nameValues.Add(ToQueryString(name, value));
 
         protected void Add(string name, bool value)
             => Add(name, value.ToLowerCaseString());
@@ -80,14 +78,11 @@ namespace GitLabApiClient.Internal.Queries
             }
         }
 
-        private static string ToQueryString(NameValueCollection nvc)
+        private static string ToQueryString(List<string> dic)
         {
-            var array =
-                from key in nvc.AllKeys
-                from value in nvc.GetValues(key)
-                select $"{key.UrlEncode()}={value.UrlEncode()}";
-
-            return $"?{string.Join("&", array)}";
+            return $"?{string.Join("&", dic)}";
         }
+
+        private static string ToQueryString(string key, string value) => $"{key.UrlEncode()}={value.UrlEncode()}";
     }
 }

--- a/src/GitLabApiClient/Internal/Queries/TreeQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/TreeQueryBuilder.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using GitLabApiClient.Models.Trees.Requests;
-using GitLabApiClient.Models.Tags.Requests;
 
 namespace GitLabApiClient.Internal.Queries
 {

--- a/src/GitLabApiClient/IssuesClient.cs
+++ b/src/GitLabApiClient/IssuesClient.cs
@@ -23,18 +23,8 @@ namespace GitLabApiClient
     public sealed class IssuesClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly IssuesQueryBuilder _queryBuilder;
-        private readonly ProjectIssueNotesQueryBuilder _projectIssueNotesQueryBuilder;
 
-        internal IssuesClient(
-            GitLabHttpFacade httpFacade,
-            IssuesQueryBuilder queryBuilder,
-            ProjectIssueNotesQueryBuilder projectIssueNotesQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _queryBuilder = queryBuilder;
-            _projectIssueNotesQueryBuilder = projectIssueNotesQueryBuilder;
-        }
+        internal IssuesClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves issues.
@@ -89,7 +79,7 @@ namespace GitLabApiClient
                 path = $"groups/{groupId}/issues";
             }
 
-            string url = _queryBuilder.Build(path, queryOptions);
+            string url = new IssuesQueryBuilder().Build(path, queryOptions);
 
             return await _httpFacade.GetPagedList<Issue>(url);
         }
@@ -143,7 +133,7 @@ namespace GitLabApiClient
             var queryOptions = new IssueNotesQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _projectIssueNotesQueryBuilder.Build($"projects/{projectId}/issues/{issueIid}/notes", queryOptions);
+            string url = new ProjectIssueNotesQueryBuilder().Build($"projects/{projectId}/issues/{issueIid}/notes", queryOptions);
             return await _httpFacade.GetPagedList<Note>(url);
         }
 

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -22,21 +22,8 @@ namespace GitLabApiClient
     public sealed class MergeRequestsClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly MergeRequestsQueryBuilder _mergeRequestsQueryBuilder;
-        private readonly ProjectMergeRequestsQueryBuilder _projectMergeRequestsQueryBuilder;
-        private readonly ProjectMergeRequestsNotesQueryBuilder _projectMergeRequestNotesQueryBuilder;
 
-        internal MergeRequestsClient(
-            GitLabHttpFacade httpFacade,
-            MergeRequestsQueryBuilder mergeRequestsQueryBuilder,
-            ProjectMergeRequestsQueryBuilder projectMergeRequestsQueryBuilder,
-            ProjectMergeRequestsNotesQueryBuilder projectMergeRequestNotesQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _mergeRequestsQueryBuilder = mergeRequestsQueryBuilder;
-            _projectMergeRequestsQueryBuilder = projectMergeRequestsQueryBuilder;
-            _projectMergeRequestNotesQueryBuilder = projectMergeRequestNotesQueryBuilder;
-        }
+        internal MergeRequestsClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves merge request from a project.
@@ -50,7 +37,7 @@ namespace GitLabApiClient
             var projectMergeRequestOptions = new ProjectMergeRequestsQueryOptions();
             options?.Invoke(projectMergeRequestOptions);
 
-            string query = _projectMergeRequestsQueryBuilder.
+            string query = new MergeRequestsQueryBuilder().
                 Build($"projects/{projectId}/merge_requests", projectMergeRequestOptions);
 
             return await _httpFacade.GetPagedList<MergeRequest>(query);
@@ -67,7 +54,7 @@ namespace GitLabApiClient
             var mergeRequestOptions = new MergeRequestsQueryOptions();
             options?.Invoke(mergeRequestOptions);
 
-            string query = _mergeRequestsQueryBuilder.
+            string query = new MergeRequestsQueryBuilder().
                 Build("merge_requests", mergeRequestOptions);
 
             return await _httpFacade.GetPagedList<MergeRequest>(query);
@@ -125,7 +112,7 @@ namespace GitLabApiClient
             var queryOptions = new MergeRequestNotesQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _projectMergeRequestNotesQueryBuilder.Build($"projects/{projectId}/merge_requests/{mergeRequestIid}/notes", queryOptions);
+            string url = new ProjectMergeRequestsNotesQueryBuilder().Build($"projects/{projectId}/merge_requests/{mergeRequestIid}/notes", queryOptions);
             return await _httpFacade.GetPagedList<Note>(url);
         }
     }

--- a/src/GitLabApiClient/PipelineClient.cs
+++ b/src/GitLabApiClient/PipelineClient.cs
@@ -13,15 +13,8 @@ namespace GitLabApiClient
     public sealed class PipelineClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly PipelineQueryBuilder _queryBuilder;
-        private readonly JobQueryBuilder _jobQueryBuilder;
 
-        internal PipelineClient(GitLabHttpFacade httpFacade, PipelineQueryBuilder queryBuilder, JobQueryBuilder jobQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _queryBuilder = queryBuilder;
-            _jobQueryBuilder = jobQueryBuilder;
-        }
+        internal PipelineClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         public async Task<PipelineDetail> GetAsync(ProjectId projectId, int pipelineId) =>
             await _httpFacade.Get<PipelineDetail>($"projects/{projectId}/pipelines/{pipelineId}");
@@ -31,7 +24,7 @@ namespace GitLabApiClient
             var queryOptions = new PipelineQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryBuilder.Build($"projects/{projectId}/pipelines", queryOptions);
+            string url = new PipelineQueryBuilder().Build($"projects/{projectId}/pipelines", queryOptions);
             return await _httpFacade.GetPagedList<Pipeline>(url);
         }
 
@@ -43,7 +36,7 @@ namespace GitLabApiClient
             var queryOptions = new JobQueryOptions();
             options?.Invoke(queryOptions);
 
-            var url = _jobQueryBuilder.Build($"projects/{projectId}/pipelines/{pipelineId}/jobs", queryOptions);
+            string url = new JobQueryBuilder().Build($"projects/{projectId}/pipelines/{pipelineId}/jobs", queryOptions);
             return await _httpFacade.GetPagedList<Job>(url);
         }
 

--- a/src/GitLabApiClient/ProjectsClient.cs
+++ b/src/GitLabApiClient/ProjectsClient.cs
@@ -27,17 +27,8 @@ namespace GitLabApiClient
     public sealed class ProjectsClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly ProjectsQueryBuilder _queryBuilder;
-        private readonly MilestonesQueryBuilder _queryMilestonesBuilder;
-        private readonly JobQueryBuilder _jobQueryBuilder;
 
-        internal ProjectsClient(GitLabHttpFacade httpFacade, ProjectsQueryBuilder queryBuilder, MilestonesQueryBuilder queryMilestonesBuilder, JobQueryBuilder jobQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _queryBuilder = queryBuilder;
-            _queryMilestonesBuilder = queryMilestonesBuilder;
-            _jobQueryBuilder = jobQueryBuilder;
-        }
+        internal ProjectsClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves project by its id, path or <see cref="Project"/>.
@@ -56,7 +47,7 @@ namespace GitLabApiClient
             var queryOptions = new ProjectQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryBuilder.Build("projects", queryOptions);
+            string url = new ProjectsQueryBuilder().Build("projects", queryOptions);
             return await _httpFacade.GetPagedList<Project>(url);
         }
 
@@ -91,7 +82,7 @@ namespace GitLabApiClient
             var queryOptions = new MilestonesQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryMilestonesBuilder.Build($"projects/{projectId}/milestones", queryOptions);
+            string url = new MilestonesQueryBuilder().Build($"projects/{projectId}/milestones", queryOptions);
             return await _httpFacade.GetPagedList<Milestone>(url);
         }
 
@@ -105,7 +96,7 @@ namespace GitLabApiClient
             var queryOptions = new JobQueryOptions();
             options?.Invoke(queryOptions);
 
-            var url = _jobQueryBuilder.Build($"projects/{projectId}/jobs", queryOptions);
+            string url = new JobQueryBuilder().Build($"projects/{projectId}/jobs", queryOptions);
             return await _httpFacade.GetPagedList<Job>(url);
         }
 

--- a/src/GitLabApiClient/ReleaseClient.cs
+++ b/src/GitLabApiClient/ReleaseClient.cs
@@ -14,15 +14,8 @@ namespace GitLabApiClient
     public sealed class ReleaseClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly ReleaseQueryBuilder _releaseQueryBuilder;
 
-        internal ReleaseClient(
-            GitLabHttpFacade httpFacade,
-            ReleaseQueryBuilder releaseQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _releaseQueryBuilder = releaseQueryBuilder;
-        }
+        internal ReleaseClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves a release by its name
@@ -44,7 +37,7 @@ namespace GitLabApiClient
             var queryOptions = new ReleaseQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _releaseQueryBuilder.Build($"projects/{projectId}/releases", queryOptions);
+            string url = new ReleaseQueryBuilder().Build($"projects/{projectId}/releases", queryOptions);
             return await _httpFacade.GetPagedList<Release>(url);
         }
 

--- a/src/GitLabApiClient/TagClient.cs
+++ b/src/GitLabApiClient/TagClient.cs
@@ -13,15 +13,8 @@ namespace GitLabApiClient
     public sealed class TagClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly TagQueryBuilder _tagQueryBuilder;
 
-        internal TagClient(
-            GitLabHttpFacade httpFacade,
-            TagQueryBuilder tagQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _tagQueryBuilder = tagQueryBuilder;
-        }
+        internal TagClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Retrieves a tag by its name
@@ -43,7 +36,7 @@ namespace GitLabApiClient
             var queryOptions = new TagQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _tagQueryBuilder.Build($"projects/{projectId}/repository/tags", queryOptions);
+            string url = new TagQueryBuilder().Build($"projects/{projectId}/repository/tags", queryOptions);
             return await _httpFacade.GetPagedList<Tag>(url);
         }
 

--- a/src/GitLabApiClient/ToDoListClient.cs
+++ b/src/GitLabApiClient/ToDoListClient.cs
@@ -17,13 +17,8 @@ namespace GitLabApiClient
     public sealed class ToDoListClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly ToDoListQueryBuilder _queryBuilder;
 
-        internal ToDoListClient(GitLabHttpFacade httpFacade, ToDoListQueryBuilder queryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _queryBuilder = queryBuilder;
-        }
+        internal ToDoListClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         /// <summary>
         /// Get a list of ToDos for current user.
@@ -34,7 +29,7 @@ namespace GitLabApiClient
             var queryOptions = new ToDoListQueryOptions();
             options?.Invoke(queryOptions);
 
-            string url = _queryBuilder.Build("todos", queryOptions);
+            string url = new ToDoListQueryBuilder().Build("todos", queryOptions);
             return await _httpFacade.GetPagedList<IToDo>(url);
         }
 

--- a/src/GitLabApiClient/TreesClient.cs
+++ b/src/GitLabApiClient/TreesClient.cs
@@ -12,20 +12,14 @@ namespace GitLabApiClient
     public sealed class TreesClient
     {
         private readonly GitLabHttpFacade _httpFacade;
-        private readonly TreeQueryBuilder _treeQueryBuilder;
 
-        internal TreesClient(GitLabHttpFacade httpFacade, TreeQueryBuilder treeQueryBuilder)
-        {
-            _httpFacade = httpFacade;
-            _treeQueryBuilder = treeQueryBuilder;
-        }
+        internal TreesClient(GitLabHttpFacade httpFacade) => _httpFacade = httpFacade;
 
         public async Task<IList<Tree>> GetAsync(ProjectId projectId, Action<TreeQueryOptions> options = null)
         {
             var queryOptions = new TreeQueryOptions();
             options?.Invoke(queryOptions);
-
-            string url = _treeQueryBuilder.Build($"projects/{projectId}/repository/tree", queryOptions);
+            string url = new TreeQueryBuilder().Build($"projects/{projectId}/repository/tree", queryOptions);
             return await _httpFacade.GetPagedList<Tree>(url);
         }
     }

--- a/test/GitLabApiClient.Test/CommitsClientTest.cs
+++ b/test/GitLabApiClient.Test/CommitsClientTest.cs
@@ -6,7 +6,6 @@ using FakeItEasy;
 using FluentAssertions;
 using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Http.Serialization;
-using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Test.TestUtilities;
 using Xunit;
 
@@ -30,7 +29,7 @@ namespace GitLabApiClient.Test
             using (var client = new HttpClient(handler) { BaseAddress = new Uri(gitlabServer) })
             {
                 var gitlabHttpFacade = new GitLabHttpFacade(new RequestsJsonSerializer(), client);
-                var commitsClient = new CommitsClient(gitlabHttpFacade, new CommitQueryBuilder(), new CommitRefsQueryBuilder(), new CommitStatusesQueryBuilder());
+                var commitsClient = new CommitsClient(gitlabHttpFacade);
 
                 var commitFromClient = await commitsClient.GetAsync(projectId, sha);
                 commitFromClient.Id.Should().BeEquivalentTo(sha);
@@ -52,7 +51,7 @@ namespace GitLabApiClient.Test
             using (var client = new HttpClient(handler) { BaseAddress = new Uri(gitlabServer) })
             {
                 var gitlabHttpFacade = new GitLabHttpFacade(new RequestsJsonSerializer(), client);
-                var commitsClient = new CommitsClient(gitlabHttpFacade, new CommitQueryBuilder(), new CommitRefsQueryBuilder(), new CommitStatusesQueryBuilder());
+                var commitsClient = new CommitsClient(gitlabHttpFacade);
 
                 var commitsFromClient = await commitsClient.GetAsync(projectId, o => o.RefName = refName);
                 commitsFromClient[0].Id.Should().BeEquivalentTo("id1");
@@ -76,7 +75,7 @@ namespace GitLabApiClient.Test
             using (var client = new HttpClient(handler) { BaseAddress = new Uri(gitlabServer) })
             {
                 var gitlabHttpFacade = new GitLabHttpFacade(new RequestsJsonSerializer(), client);
-                var commitsClient = new CommitsClient(gitlabHttpFacade, new CommitQueryBuilder(), new CommitRefsQueryBuilder(), new CommitStatusesQueryBuilder());
+                var commitsClient = new CommitsClient(gitlabHttpFacade);
 
                 var diffsFromClient = await commitsClient.GetDiffsAsync(projectId, sha);
                 diffsFromClient[0].DiffText.Should().BeEquivalentTo("diff1");
@@ -116,7 +115,7 @@ namespace GitLabApiClient.Test
             using (var client = new HttpClient(handler) { BaseAddress = new Uri(gitlabServer) })
             {
                 var gitlabHttpFacade = new GitLabHttpFacade(new RequestsJsonSerializer(), client);
-                var commitsClient = new CommitsClient(gitlabHttpFacade, new CommitQueryBuilder(), new CommitRefsQueryBuilder(), new CommitStatusesQueryBuilder());
+                var commitsClient = new CommitsClient(gitlabHttpFacade);
 
                 var statusesFromClient = await commitsClient.GetStatusesAsync(projectId, sha, o => o.Name = Name);
                 statusesFromClient[0].Status.Should().BeEquivalentTo("success");

--- a/test/GitLabApiClient.Test/GroupsClientTest.cs
+++ b/test/GitLabApiClient.Test/GroupsClientTest.cs
@@ -20,12 +20,7 @@ namespace GitLabApiClient.Test
         private readonly List<int> _groupIdsToClean = new List<int>();
         private List<int> MilestoneIdsToClean { get; } = new List<int>();
 
-        private readonly GroupsClient _sut = new GroupsClient(
-            GetFacade(),
-            new GroupsQueryBuilder(),
-            new ProjectsGroupQueryBuilder(),
-            new MilestonesQueryBuilder(),
-            new GroupLabelsQueryBuilder());
+        private readonly GroupsClient _sut = new GroupsClient(GetFacade());
 
         [Fact]
         public async Task GroupCanBeRetrievedByGroupId()

--- a/test/GitLabApiClient.Test/IssuesClientTest.cs
+++ b/test/GitLabApiClient.Test/IssuesClientTest.cs
@@ -18,8 +18,7 @@ namespace GitLabApiClient.Test
     [Collection("GitLabContainerFixture")]
     public class IssuesClientTest
     {
-        private readonly IssuesClient _sut = new IssuesClient(
-            GetFacade(), new IssuesQueryBuilder(), new ProjectIssueNotesQueryBuilder());
+        private readonly IssuesClient _sut = new IssuesClient(GetFacade());
 
         [Fact]
         public async Task CreatedIssueCanBeUpdated()

--- a/test/GitLabApiClient.Test/MergeRequestClientTest.cs
+++ b/test/GitLabApiClient.Test/MergeRequestClientTest.cs
@@ -16,9 +16,7 @@ namespace GitLabApiClient.Test
     [Collection("GitLabContainerFixture")]
     public class MergeRequestClientTest : IAsyncLifetime
     {
-        private readonly MergeRequestsClient _sut = new MergeRequestsClient(
-            GitLabApiHelper.GetFacade(), new MergeRequestsQueryBuilder(), new ProjectMergeRequestsQueryBuilder(),
-            new ProjectMergeRequestsNotesQueryBuilder());
+        private readonly MergeRequestsClient _sut = new MergeRequestsClient(GitLabApiHelper.GetFacade());
 
         [Fact]
         public async Task CreatedMergeRequestCanBeRetrieved()

--- a/test/GitLabApiClient.Test/ProjectsClientTest.cs
+++ b/test/GitLabApiClient.Test/ProjectsClientTest.cs
@@ -24,11 +24,7 @@ namespace GitLabApiClient.Test
         private List<int> MilestoneIdsToClean { get; } = new List<int>();
         private List<string> VariableIdsToClean { get; } = new List<string>();
 
-        private readonly ProjectsClient _sut = new ProjectsClient(
-            GitLabApiHelper.GetFacade(),
-            new ProjectsQueryBuilder(),
-            new MilestonesQueryBuilder(),
-            new JobQueryBuilder());
+        private readonly ProjectsClient _sut = new ProjectsClient(GitLabApiHelper.GetFacade());
 
         [Fact]
         public async Task ProjectRetrieved()

--- a/test/GitLabApiClient.Test/ReleasesTest.cs
+++ b/test/GitLabApiClient.Test/ReleasesTest.cs
@@ -15,7 +15,7 @@ namespace GitLabApiClient.Test
     [Collection("GitLabContainerFixture")]
     public class ReleasesTest
     {
-        private readonly ReleaseClient _sut = new ReleaseClient(GetFacade(), new ReleaseQueryBuilder());
+        private readonly ReleaseClient _sut = new ReleaseClient(GetFacade());
 
         [Fact]
         public async Task CreatedReleaseCanBeUpdated()

--- a/test/GitLabApiClient.Test/ToDoListClientTest.cs
+++ b/test/GitLabApiClient.Test/ToDoListClientTest.cs
@@ -17,13 +17,11 @@ namespace GitLabApiClient.Test
     [Collection("GitLabContainerFixture")]
     public class ToDoListClientTest : IAsyncLifetime
     {
-        private readonly MergeRequestsClient mergeRequestsClient = new MergeRequestsClient(GitLabApiHelper.GetFacade(), new MergeRequestsQueryBuilder(), new ProjectMergeRequestsQueryBuilder(), new ProjectMergeRequestsNotesQueryBuilder());
-        private readonly IssuesClient issuesClient = new IssuesClient(GitLabApiHelper.GetFacade(), new IssuesQueryBuilder(), new ProjectIssueNotesQueryBuilder());
+        private readonly MergeRequestsClient mergeRequestsClient = new MergeRequestsClient(GitLabApiHelper.GetFacade());
+        private readonly IssuesClient issuesClient = new IssuesClient(GitLabApiHelper.GetFacade());
 
 
-        private readonly ToDoListClient _sut = new ToDoListClient(
-            GitLabApiHelper.GetFacade(),
-            new ToDoListQueryBuilder());
+        private readonly ToDoListClient _sut = new ToDoListClient(GitLabApiHelper.GetFacade());
 
         [Fact]
         public async Task RetrieveToDoListAndMarkAsDone()

--- a/test/GitLabApiClient.Test/TreesClientTest.cs
+++ b/test/GitLabApiClient.Test/TreesClientTest.cs
@@ -10,7 +10,7 @@ namespace GitLabApiClient.Test
     [Collection("GitLabContainerFixture")]
     public class TreesClientTest
     {
-        private readonly TreesClient _sut = new TreesClient(GetFacade(), new TreeQueryBuilder());
+        private readonly TreesClient _sut = new TreesClient(GetFacade());
 
         [Fact]
         public async Task GetTrees()


### PR DESCRIPTION
When the API client is used from multiple sources,
we can't guarantee correct access to shared NameValueCollection keys.
The easiest way to fix the problem is to use a separate
instance of QueryBuilder class for each request.