### PR TITLE
Add missing enum member `checking` to the MergeStatus.cs

### DIFF
--- a/src/GitLabApiClient/Models/MergeRequests/Responses/MergeStatus.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Responses/MergeStatus.cs
@@ -9,6 +9,8 @@ namespace GitLabApiClient.Models.MergeRequests.Responses
         [EnumMember(Value = "can_be_merged")]
         CanBeMerged,
         [EnumMember(Value = "cannot_be_merged")]
-        CannotBeMerged
+        CannotBeMerged,
+        [EnumMember(Value = "checking")]
+        Checking
     }
 }


### PR DESCRIPTION
Fix issue #118 by adding the missing enum member to the `MergeStatus` enum.