### PR TITLE
Add ability for pagination with Project's GetAsync

### DIFF
--- a/src/GitLabApiClient/IProjectsClient.cs
+++ b/src/GitLabApiClient/IProjectsClient.cs
@@ -31,6 +31,22 @@ namespace GitLabApiClient
         Task<IList<Project>> GetAsync(Action<ProjectQueryOptions> options = null);
 
         /// <summary>
+        /// Get a specified page of projects for authenticated user.
+        /// </summary>
+        /// <param name="pageNumber"></param>
+        /// <param name="maxItemsPerPage"></param>
+        /// <param name="options"></param>
+        Task<IList<Project>> GetPageAsync(int pageNumber = 1,
+            int? maxItemsPerPage = null,
+            Action<ProjectQueryOptions> options = null);
+
+        /// <summary>
+        /// Get the total number of pages available for authenticated user.
+        /// </summary>
+        /// <param name="options"></param>
+        Task<int> GetTotalPageCount(Action<ProjectQueryOptions> options = null);
+
+        /// <summary>
         /// Get the users list of a project.
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>

--- a/src/GitLabApiClient/IProjectsClient.cs
+++ b/src/GitLabApiClient/IProjectsClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Models;
 using GitLabApiClient.Models.Job.Requests;
 using GitLabApiClient.Models.Job.Responses;
 using GitLabApiClient.Models.Milestones.Requests;
@@ -33,18 +34,10 @@ namespace GitLabApiClient
         /// <summary>
         /// Get a specified page of projects for authenticated user.
         /// </summary>
-        /// <param name="pageNumber"></param>
-        /// <param name="maxItemsPerPage"></param>
+        /// <param name="pageOptions"></param>
         /// <param name="options"></param>
-        Task<IList<Project>> GetPageAsync(int pageNumber = 1,
-            int? maxItemsPerPage = null,
-            Action<ProjectQueryOptions> options = null);
-
-        /// <summary>
-        /// Get the total number of pages available for authenticated user.
-        /// </summary>
-        /// <param name="options"></param>
-        Task<int> GetTotalPageCount(Action<ProjectQueryOptions> options = null);
+        /// <returns></returns>
+        Task<IList<Project>> GetAsync(PaginationOptions pageOptions, Action<ProjectQueryOptions> options = null);
 
         /// <summary>
         /// Get the users list of a project.

--- a/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabApiPagedRequestor.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models;
 
 namespace GitLabApiClient.Internal.Http
 {
@@ -38,14 +39,6 @@ namespace GitLabApiClient.Internal.Http
                 default:
                     return await GetTotalPagedList(url, totalPages, result);
             }
-        }
-
-        public async Task<int> GetTotalPageCount<T>(string url)
-        {
-            var response = await _requestor.GetWithHeaders<IList<T>>(GetPagedUrl(url, 1));
-            var headers = response.Item2;
-            int totalPages = headers.GetFirstHeaderValueOrDefault<int>("X-Total-Pages");
-            return totalPages;
         }
 
         private async Task<IList<T>> GetNextPageList<T>(string url, int nextPage, List<T> result)
@@ -87,10 +80,10 @@ namespace GitLabApiClient.Internal.Http
             return result;
         }
 
-        public async Task<IList<T>> GetPage<T>(string url, int pageNumber, int? maxItemsPerPage)
+        public async Task<IList<T>> GetPage<T>(string url, PaginationOptions paginationOptions)
         {
-            int maxItems = maxItemsPerPage ?? MaxItemsPerPage;
-            string pagedUrl = GetPagedUrl(url, pageNumber, maxItems);
+            int maxItems = paginationOptions.MaxItemsPerPage ?? MaxItemsPerPage;
+            string pagedUrl = GetPagedUrl(url, paginationOptions.PageNumber, maxItems);
             var results = await _requestor.Get<IList<T>>(pagedUrl);
             return results;
         }

--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using GitLabApiClient.Internal.Http.Serialization;
+using GitLabApiClient.Models;
 using GitLabApiClient.Models.Oauth.Requests;
 using GitLabApiClient.Models.Oauth.Responses;
 using GitLabApiClient.Models.Uploads.Requests;
@@ -63,11 +64,8 @@ namespace GitLabApiClient.Internal.Http
         public Task<IList<T>> GetPagedList<T>(string uri) =>
             _pagedRequestor.GetPagedList<T>(uri);
 
-        public Task<IList<T>> GetPage<T>(string uri, int pageNumber, int? maxItemsPerPage) =>
-            _pagedRequestor.GetPage<T>(uri, pageNumber, maxItemsPerPage);
-
-        public Task<int> GetTotalPageCount<T>(string uri) =>
-            _pagedRequestor.GetTotalPageCount<T>(uri);
+        public Task<IList<T>> GetPage<T>(string uri, PaginationOptions paginationOptions) =>
+            _pagedRequestor.GetPage<T>(uri, paginationOptions);
 
         public Task<T> Get<T>(string uri) =>
             _requestor.Get<T>(uri);

--- a/src/GitLabApiClient/Models/PaginationOptions.cs
+++ b/src/GitLabApiClient/Models/PaginationOptions.cs
@@ -1,0 +1,18 @@
+namespace GitLabApiClient.Models
+{
+    /// <summary>
+    /// Request options for pagination
+    /// </summary>
+    public class PaginationOptions
+    {
+        /// <summary>
+        /// Requested page number
+        /// </summary>
+        public int PageNumber { get; set; }
+
+        /// <summary>
+        /// Maximum number of results returned per page
+        /// </summary>
+        public int? MaxItemsPerPage { get; set; }
+    }
+}

--- a/src/GitLabApiClient/ProjectsClient.cs
+++ b/src/GitLabApiClient/ProjectsClient.cs
@@ -70,12 +70,12 @@ namespace GitLabApiClient
             return await _httpFacade.GetPage<Project>(url, pageNumber, maxItemsPerPage);
         }
 
-        public async Task<int> GetTotalPageCount<T>(Action<ProjectQueryOptions> options = null)
+        public async Task<int> GetTotalPageCount(Action<ProjectQueryOptions> options = null)
         {
             var queryOptions = new ProjectQueryOptions();
             options?.Invoke(queryOptions);
             string url = _queryBuilder.Build("projects", queryOptions);
-            return await _httpFacade.GetTotalPageCount<T>(url);
+            return await _httpFacade.GetTotalPageCount<Project>(url);
         }
 
         /// <summary>

--- a/src/GitLabApiClient/ProjectsClient.cs
+++ b/src/GitLabApiClient/ProjectsClient.cs
@@ -6,6 +6,7 @@ using GitLabApiClient.Internal.Http;
 using GitLabApiClient.Internal.Paths;
 using GitLabApiClient.Internal.Queries;
 using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models;
 using GitLabApiClient.Models.Job.Requests;
 using GitLabApiClient.Models.Job.Responses;
 using GitLabApiClient.Models.Milestones.Requests;
@@ -47,7 +48,7 @@ namespace GitLabApiClient
             await _httpFacade.Get<Project>($"projects/{projectId}");
 
         /// <summary>
-        /// Get a list of visible projects for authenticated user.
+        /// Get a list of all visible projects for authenticated user.
         /// When accessed without authentication, only public projects are returned.
         /// </summary>
         /// <param name="options">Query options.</param>
@@ -60,22 +61,20 @@ namespace GitLabApiClient
             return await _httpFacade.GetPagedList<Project>(url);
         }
 
-        public async Task<IList<Project>> GetPageAsync(int pageNumber = 1,
-            int? maxItemsPerPage = null,
+        /// <summary>
+        /// Get a list of visible projects for authenticated user.
+        /// List size is based on pagination options.
+        /// When accessed without authentication, only public projects are returned.
+        /// </summary>
+        /// <param name="paginationOptions"></param>
+        /// <param name="options"></param>
+        public async Task<IList<Project>> GetAsync(PaginationOptions paginationOptions,
             Action<ProjectQueryOptions> options = null)
         {
             var queryOptions = new ProjectQueryOptions();
             options?.Invoke(queryOptions);
             string url = _queryBuilder.Build("projects", queryOptions);
-            return await _httpFacade.GetPage<Project>(url, pageNumber, maxItemsPerPage);
-        }
-
-        public async Task<int> GetTotalPageCount(Action<ProjectQueryOptions> options = null)
-        {
-            var queryOptions = new ProjectQueryOptions();
-            options?.Invoke(queryOptions);
-            string url = _queryBuilder.Build("projects", queryOptions);
-            return await _httpFacade.GetTotalPageCount<Project>(url);
+            return await _httpFacade.GetPage<Project>(url, paginationOptions);
         }
 
         /// <summary>


### PR DESCRIPTION
- Adds overridden method `GetAsync` to the ProjectsClient
- PaginationOptions allows for gathering page x of size n
- ProjectQueryOptions work with pagination as expected