### PR TITLE
Add option to force random password option when creating new user

### DIFF
--- a/src/GitLabApiClient/Models/Users/Requests/CreateUserRequest.cs
+++ b/src/GitLabApiClient/Models/Users/Requests/CreateUserRequest.cs
@@ -57,6 +57,12 @@ namespace GitLabApiClient.Models.Users.Requests
         public bool? ResetPassword { get; set; } = true;
 
         /// <summary>
+        /// Generate random password on the server.
+        /// </summary>
+        [JsonProperty("force_random_password")]
+        public bool? ForceRandomPassword { get; set; } = true;
+
+        /// <summary>
         /// Skype ID
         /// </summary>
         [JsonProperty("skype")]


### PR DESCRIPTION
Added an option to force a random password when creating a new user in GitLab