### PR TITLE
Added target_branch query param to merge requests query builder

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/MergeRequestsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/MergeRequestsQueryBuilder.cs
@@ -42,6 +42,9 @@ namespace GitLabApiClient.Internal.Queries
 
             if (options.AssigneeId.HasValue)
                 query.Add("assignee_id", options.AssigneeId.Value);
+
+            if (!string.IsNullOrEmpty(options.TargetBranch))
+                query.Add("target_branch", options.TargetBranch);
         }
 
         private static string GetStateQueryValue(QueryMergeRequestState state)

--- a/src/GitLabApiClient/Models/MergeRequests/Requests/MergeRequestsQueryOptions.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Requests/MergeRequestsQueryOptions.cs
@@ -66,5 +66,10 @@ namespace GitLabApiClient.Models.MergeRequests.Requests
         /// Returns merge requests assigned to the given user id.
         /// </summary>
         public int? AssigneeId { get; set; }
+
+        /// <summary>
+        /// Returns merge requests targetting the given branch.
+        /// </summary>
+        public string TargetBranch { get; set; }
     }
 }

--- a/test/GitLabApiClient.Test/Internal/Queries/MergeRequestsQueryBuilderTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Queries/MergeRequestsQueryBuilderTest.cs
@@ -28,7 +28,8 @@ namespace GitLabApiClient.Test.Internal.Queries
                     CreatedBefore = new DateTime(1991, 12, 12, 2, 2, 2),
                     Scope = Scope.All,
                     AuthorId = 1,
-                    AssigneeId = 2
+                    AssigneeId = 2,
+                    TargetBranch = "targetBranch1"
                 });
 
             query.Should().Be("https://gitlab.com/api/v4/merge_requests?" +
@@ -42,7 +43,8 @@ namespace GitLabApiClient.Test.Internal.Queries
                               "created_before=1991-12-12T02%3A02%3A02.0000000&" +
                               "scope=all&" +
                               "author_id=1&" +
-                              "assignee_id=2");
+                              "assignee_id=2&" +
+                              "target_branch=targetBranch1");
         }
     }
 }


### PR DESCRIPTION
Allows merge requests to be filtered by the target branch when using `MergeRequestClient#GetAsync`