### PR TITLE
Add MergeRequestsCount to Issue response

### DIFF
--- a/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
+++ b/src/GitLabApiClient/Models/Issues/Responses/Issue.cs
@@ -43,6 +43,9 @@ namespace GitLabApiClient.Models.Issues.Responses
         [JsonProperty("title")]
         public string Title { get; set; }
 
+        [JsonProperty("merge_requests_count")]
+        public int MergeRequestsCount { get; set; }
+
         [JsonProperty("user_notes_count")]
         public int UserNotesCount { get; set; }
 


### PR DESCRIPTION
Add `MergeRequestsCount` property on the `Issue` response (see https://docs.gitlab.com/ee/api/issues.html#list-issues ).