### PR TITLE
Change int to long for all project statistic values

### DIFF
--- a/src/GitLabApiClient/Models/Projects/Responses/Statistics.cs
+++ b/src/GitLabApiClient/Models/Projects/Responses/Statistics.cs
@@ -5,18 +5,18 @@ namespace GitLabApiClient.Models.Projects.Responses
     public sealed class Statistics
     {
         [JsonProperty("job_artifacts_size")]
-        public int JobArtifactsSize { get; set; }
+        public long JobArtifactsSize { get; set; }
 
         [JsonProperty("repository_size")]
-        public int RepositorySize { get; set; }
+        public long RepositorySize { get; set; }
 
         [JsonProperty("commit_count")]
-        public int CommitCount { get; set; }
+        public long CommitCount { get; set; }
 
         [JsonProperty("lfs_objects_size")]
-        public int LfsObjectsSize { get; set; }
+        public long LfsObjectsSize { get; set; }
 
         [JsonProperty("storage_size")]
-        public int StorageSize { get; set; }
+        public long StorageSize { get; set; }
     }
 }


### PR DESCRIPTION
# Change int to long for all project statistic values

## Summary

In this PR the datatype `int` got replaced by `long` for project statistics to prevent deserialization issues while parsing responses from the API which use long as datatype for storage_size, ....

## Purpose

This PR resolves #203

## Changes

### Changed files:

* `src/GitLabApiClient/Models/Projects/Responses/Statistics.cs`