### PR TITLE
fix(http): allow tokens to exceed 20 chars

### DIFF
--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -34,12 +34,12 @@ namespace GitLabApiClient.Internal.Http
         {
             switch (authenticationToken.Length)
             {
-                case 0:
+                case int i when i == 0:
                     break;
-                case 20:
+                case int i when i >= 20 && i < 64:
                     _httpClient.DefaultRequestHeaders.Add(PrivateToken, authenticationToken);
                     break;
-                case 64:
+                case int i when i == 64:
                     _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authenticationToken);
                     break;
                 default:


### PR DESCRIPTION
GitLab allows users of an instance to specify a token prefix since 13.8, which is where this current assumption breaks down

See: https://docs.gitlab.com/ee/user/admin_area/settings/account_and_limit_settings.html#personal-access-token-prefix