### PR TITLE
Implement Release query options.  Exception for Models/Releases in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# opt-in include Releases folder - being ignored by Build results section below
+!**/[Mm]odels/[Rr]eleases/
+
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
+++ b/src/GitLabApiClient/Internal/Http/GitLabHttpFacade.cs
@@ -36,14 +36,13 @@ namespace GitLabApiClient.Internal.Http
             {
                 case 0:
                     break;
-                case 20:
-                    _httpClient.DefaultRequestHeaders.Add(PrivateToken, authenticationToken);
-                    break;
                 case 64:
                     _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authenticationToken);
                     break;
                 default:
-                    throw new ArgumentException("Unsupported authentication token provide, please private an oauth or private token");
+                    _httpClient.DefaultRequestHeaders.Add(PrivateToken, authenticationToken);
+                    break;
+
             }
         }
 

--- a/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/ReleaseQueryBuilder.cs
@@ -1,3 +1,5 @@
+using System;
+using GitLabApiClient.Models;
 using GitLabApiClient.Models.Releases.Requests;
 
 namespace GitLabApiClient.Internal.Queries
@@ -6,6 +8,27 @@ namespace GitLabApiClient.Internal.Queries
     {
         protected override void BuildCore(Query query, ReleaseQueryOptions options)
         {
+            if (options.Order != ReleasesOrder.ReleasedAt)
+                query.Add("order_by", GetReleasesOrderQueryValue(options.Order));
+
+            if (options.SortOrder != SortOrder.Descending)
+                query.Add("sort", GetSortOrderQueryValue(options.SortOrder));
+
+            if (options.IncludeHtmlDescription)
+                query.Add("include_html_description", true);
+        }
+
+        private static string GetReleasesOrderQueryValue(ReleasesOrder order)
+        {
+            switch (order)
+            {
+                case ReleasesOrder.CreatedAt:
+                    return "created_at";
+                case ReleasesOrder.ReleasedAt:
+                    return "released_at";
+                default:
+                    throw new NotSupportedException($"Order {order} is not supported");
+            }
         }
     }
 }

--- a/src/GitLabApiClient/Models/Releases/Requests/ReleaseQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Releases/Requests/ReleaseQueryOptions.cs
@@ -5,5 +5,21 @@ namespace GitLabApiClient.Models.Releases.Requests
         internal ReleaseQueryOptions()
         {
         }
+
+        /// <summary>
+        /// Specifies releases order. Default is Released At time.
+        /// </summary>
+        public ReleasesOrder Order { get; set; }
+
+        /// <summary>
+        /// Specifies releases sort order. Default is descending.
+        /// </summary>
+        public SortOrder SortOrder { get; set; }
+
+        /// <summary>
+        /// Response includes HTML rendered Markdown of the release description. 
+        /// </summary>
+        public bool IncludeHtmlDescription { get; set; } = true;
+
     }
 }

--- a/src/GitLabApiClient/Models/Releases/Requests/ReleasesOrder.cs
+++ b/src/GitLabApiClient/Models/Releases/Requests/ReleasesOrder.cs
@@ -1,0 +1,8 @@
+namespace GitLabApiClient.Models.Releases.Requests
+{
+    public enum ReleasesOrder
+    {
+        ReleasedAt,
+        CreatedAt
+    }
+}


### PR DESCRIPTION
Added in functionality to allow specifying sort order and including HTML descriptions for Releases.   Git was ignoring Models/Releases due to the standard [Rr]eleases in .gitignore.    Both have been fixed/implemented.