### PR TITLE
Add merged_at to MergeRequest model

### DIFF
--- a/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequest.cs
+++ b/src/GitLabApiClient/Models/MergeRequests/Responses/MergeRequest.cs
@@ -92,5 +92,8 @@ namespace GitLabApiClient.Models.MergeRequests.Responses
 
         [JsonProperty("merged_by")]
         public Assignee MergedBy { get; set; }
+
+        [JsonProperty("merged_at")]
+        public DateTime? MergedAt { get; set; }
     }
 }


### PR DESCRIPTION
Missing field from API doc.

https://docs.gitlab.com/ee/api/merge_requests.html
![image](https://user-images.githubusercontent.com/5965883/148162871-547e1627-d864-455e-8b43-cb9dd1aa295a.png)