### PR TITLE
Delete note of a merge request

### DIFF
--- a/src/GitLabApiClient/IMergeRequestsClient.cs
+++ b/src/GitLabApiClient/IMergeRequestsClient.cs
@@ -92,6 +92,14 @@ namespace GitLabApiClient
         Task<IList<Note>> GetNotesAsync(ProjectId projectId, int mergeRequestIid, Action<MergeRequestNotesQueryOptions> options = null);
 
         /// <summary>
+        /// Deletes a note of a merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">Iid of the merge request.</param>
+        /// <param name="noteId">ID of the merge request note.</param>
+        Task DeleteNoteAsync(ProjectId projectId, int mergeRequestIid, int noteId);
+
+        /// <summary>
         /// List erge request pipelines
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>

--- a/src/GitLabApiClient/MergeRequestsClient.cs
+++ b/src/GitLabApiClient/MergeRequestsClient.cs
@@ -151,6 +151,17 @@ namespace GitLabApiClient
         }
 
         /// <summary>
+        /// Deletes a note of a merge request.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="mergeRequestIid">Iid of the merge request.</param>
+        /// <param name="noteId">ID of the merge request note.</param>
+        public async Task DeleteNoteAsync(ProjectId projectId, int mergeRequestIid, int noteId)
+        {
+            await _httpFacade.Delete($"projects/{projectId}/merge_requests/{mergeRequestIid}/notes/{noteId}");
+        }
+
+        /// <summary>
         /// List erge request pipelines
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>


### PR DESCRIPTION
Adding the API to delete a note on a merge request.

https://docs.gitlab.com/ee/api/notes.html#delete-a-merge-request-note