### PR TITLE
Add Environments API Support

### DIFF
--- a/src/GitLabApiClient/EnvironmentClient.cs
+++ b/src/GitLabApiClient/EnvironmentClient.cs
@@ -26,7 +26,7 @@ namespace GitLabApiClient
         }
 
         /// <summary>
-        /// Retrieves a environment by its name
+        /// Retrieves an environment by its name
         /// </summary>
         /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
         /// <param name="environmentId">The ID of the environment to retrieve.</param>
@@ -74,7 +74,7 @@ namespace GitLabApiClient
         /// <param name="tagName">The ID of the environment to stop.</param>
         /// <returns></returns>
         public async Task StopAsync(ProjectId projectId, int environmentId) =>
-            await _httpFacade.Delete($"projects/{projectId}/environments/{environmentId}/stop");
+            await _httpFacade.Post($"projects/{projectId}/environments/{environmentId}/stop");
 
         /// <summary>
         /// Delete an environment

--- a/src/GitLabApiClient/EnvironmentClient.cs
+++ b/src/GitLabApiClient/EnvironmentClient.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitLabApiClient.Internal.Http;
+using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Internal.Queries;
+using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models.Projects.Responses;
+using GitLabApiClient.Models.Environments.Requests;
+using GitLabApiClient.Models.Environments.Responses;
+using Environment = GitLabApiClient.Models.Environments.Responses.Environment;
+
+namespace GitLabApiClient
+{
+    public sealed class EnvironmentClient : IEnvironmentsClient
+    {
+        private readonly GitLabHttpFacade _httpFacade;
+        private readonly EnvironmentsQueryBuilder _environmentQueryBuilder;
+
+        internal EnvironmentClient(
+            GitLabHttpFacade httpFacade,
+            EnvironmentsQueryBuilder environmentQueryBuilder)
+        {
+            _httpFacade = httpFacade;
+            _environmentQueryBuilder = environmentQueryBuilder;
+        }
+
+        /// <summary>
+        /// Retrieves a environment by its name
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="environmentId">The ID of the environment to retrieve.</param>
+        /// <returns></returns>
+        public async Task<Environment> GetAsync(ProjectId projectId, int environmentId) =>
+            await _httpFacade.Get<Environment>($"projects/{projectId}/environments/{environmentId}");
+
+        /// <summary>
+        /// Get a list of environments
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="options">Query options <see cref="EnvironmentsQueryOptions"/>.</param>
+        /// <returns></returns>
+        public async Task<IList<Environment>> GetAsync(ProjectId projectId, Action<EnvironmentsQueryOptions> options = null)
+        {
+            var queryOptions = new EnvironmentsQueryOptions();
+            options?.Invoke(queryOptions);
+
+            string url = _environmentQueryBuilder.Build($"projects/{projectId}/environments", queryOptions);
+            return await _httpFacade.GetPagedList<Environment>(url);
+        }
+
+        /// <summary>
+        /// Create an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="request">Create environment request.</param>
+        /// <returns></returns>
+        public async Task<Environment> CreateAsync(ProjectId projectId, CreateEnvironmentRequest request) =>
+            await _httpFacade.Post<Environment>($"projects/{projectId}/environments", request);
+
+        /// <summary>
+        /// Update an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="request">Update environment request</param>
+        /// <returns></returns>
+        public async Task<Environment> UpdateAsync(ProjectId projectId, UpdateEnvironmentRequest request) =>
+            await _httpFacade.Put<Environment>($"projects/{projectId}/environments/{request.EnvironmentId}", request);
+
+        /// <summary>
+        /// Stop an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="tagName">The ID of the environment to stop.</param>
+        /// <returns></returns>
+        public async Task StopAsync(ProjectId projectId, int environmentId) =>
+            await _httpFacade.Delete($"projects/{projectId}/environments/{environmentId}/stop");
+
+        /// <summary>
+        /// Delete an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="tagName">The ID of the environment to delete.</param>
+        /// <returns></returns>
+        public async Task DeleteAsync(ProjectId projectId, int environmentId) =>
+            await _httpFacade.Delete($"projects/{projectId}/environments/{environmentId}");
+    }
+}

--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild >true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 

--- a/src/GitLabApiClient/GitLabClient.cs
+++ b/src/GitLabApiClient/GitLabClient.cs
@@ -60,6 +60,7 @@ namespace GitLabApiClient
             var jobQueryBuilder = new JobQueryBuilder();
             var toDoListBuilder = new ToDoListQueryBuilder();
             var iterationsBuilder = new IterationsQueryBuilder();
+            var environmentBuilder = new EnvironmentsQueryBuilder();
 
             Issues = new IssuesClient(_httpFacade, issuesQueryBuilder, projectIssueNotesQueryBuilder);
             Uploads = new UploadsClient(_httpFacade);
@@ -80,6 +81,7 @@ namespace GitLabApiClient
             ToDoList = new ToDoListClient(_httpFacade, toDoListBuilder);
             Iterations = new IterationsClient(_httpFacade, iterationsBuilder);
             Connection = new ConnectionClient(_httpFacade);
+            Environments = new EnvironmentClient(_httpFacade, environmentBuilder);
         }
 
         /// <summary>
@@ -174,6 +176,11 @@ namespace GitLabApiClient
 
         /// <inheritdoc/>
         public IIterationsClient Iterations { get; }
+
+        /// <summary>
+        /// Access GitLab's Environments API.
+        /// </summary>
+        public IEnvironmentsClient Environments { get; }
 
         /// <summary>
         /// Host address of GitLab instance. For example https://gitlab.example.com or https://gitlab.example.com/api/v4/.

--- a/src/GitLabApiClient/IEnvironmentsClient.cs
+++ b/src/GitLabApiClient/IEnvironmentsClient.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Models.Projects.Responses;
+using GitLabApiClient.Models.Environments.Requests;
+using GitLabApiClient.Models.Environments.Responses;
+using Environment = GitLabApiClient.Models.Environments.Responses.Environment;
+
+namespace GitLabApiClient
+{
+    public interface IEnvironmentsClient
+    {
+        /// <summary>
+        /// Get a list of environments
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="environmentId">The ID of the environment to retrieve.</param>
+        /// <returns></returns>
+        Task<Environment> GetAsync(ProjectId projectId, int environmentId);
+
+        /// <summary>
+        /// Get a list of environments
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="options">Query options <see cref="EnvironmentsQueryOptions"/>.</param>
+        /// <returns></returns>
+        Task<IList<Environment>> GetAsync(ProjectId projectId, Action<EnvironmentsQueryOptions> options = null);
+
+        /// <summary>
+        /// Create an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="request">Create environment request.</param>
+        /// <returns></returns>
+        Task<Environment> CreateAsync(ProjectId projectId, CreateEnvironmentRequest request);
+
+        /// <summary>
+        /// Update an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="request">Update environment request</param>
+        /// <returns></returns>
+        Task<Environment> UpdateAsync(ProjectId projectId, UpdateEnvironmentRequest request);
+
+        /// <summary>
+        /// Stop an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="environmentId">The ID of the environment to stop.</param>
+        /// <returns></returns>
+        Task StopAsync(ProjectId projectId, int environmentId);
+
+        /// <summary>
+        /// Delete an environment
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="environmentId">The ID of the environment to delete.</param>
+        /// <returns></returns>
+        Task DeleteAsync(ProjectId projectId, int environmentId);
+    }
+}

--- a/src/GitLabApiClient/Internal/Queries/EnvironmentsQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/EnvironmentsQueryBuilder.cs
@@ -1,0 +1,23 @@
+using System;
+using GitLabApiClient.Models.Environments.Requests;
+
+namespace GitLabApiClient.Internal.Queries
+{
+    class EnvironmentsQueryBuilder : QueryBuilder<EnvironmentsQueryOptions>
+    {
+        protected override void BuildCore(Query query, EnvironmentsQueryOptions options)
+        {
+            if (!string.IsNullOrEmpty(options.Name) && !string.IsNullOrEmpty(options.Search))
+                throw new InvalidOperationException("Environment queries for 'name' and 'search' are mutually exclusive.");
+
+            if (!string.IsNullOrEmpty(options.Name))
+                query.Add("name", options.Name);
+
+            if (!string.IsNullOrEmpty(options.Search))
+                query.Add("search", options.Search);
+
+            if (options.States != null)
+                query.Add("states", options.States.ToString().ToLowerInvariant());
+        }
+    }
+}

--- a/src/GitLabApiClient/Models/Environments/Requests/CreateEnvironmentRequest.cs
+++ b/src/GitLabApiClient/Models/Environments/Requests/CreateEnvironmentRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using GitLabApiClient.Internal.Utilities;
+using GitLabApiClient.Models.Environments.Responses;
+using Newtonsoft.Json;
+using Environment = GitLabApiClient.Models.Environments.Responses.Environment;
+
+namespace GitLabApiClient.Models.Environments.Requests
+{
+    /// <summary>
+    /// Used to create an environment in a project.
+    /// </summary>
+    public sealed class CreateEnvironmentRequest : Environment
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CreateEnvironmentRequest"/> class.
+        /// </summary>
+        /// <param name="name">The name of the environment.</param>
+        /// <param name="externalUrl">The external URL for the environment.</param>
+        public CreateEnvironmentRequest(string name, Uri externalUrl)
+        {
+            Guard.NotEmpty(name, nameof(name));
+            Guard.NotNullOrDefault(externalUrl, nameof(externalUrl));
+
+            Name = name;
+            ExternalUrl = externalUrl;
+        }
+    }
+}

--- a/src/GitLabApiClient/Models/Environments/Requests/EnvironmentsQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Environments/Requests/EnvironmentsQueryOptions.cs
@@ -1,0 +1,17 @@
+using GitLabApiClient.Models.Environments.Responses;
+
+namespace GitLabApiClient.Models.Environments.Requests
+{
+    public sealed class EnvironmentsQueryOptions
+    {
+        public string Name { get; set; }
+
+        public string Search { get; set; }
+
+        public EnvironmentState? States { get; set; }
+
+        internal EnvironmentsQueryOptions()
+        {
+        }
+    }
+}

--- a/src/GitLabApiClient/Models/Environments/Requests/UpdateEnvironmentRequest.cs
+++ b/src/GitLabApiClient/Models/Environments/Requests/UpdateEnvironmentRequest.cs
@@ -1,0 +1,32 @@
+using System;
+using GitLabApiClient.Internal.Utilities;
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Environments.Requests
+{
+    /// <summary>
+    /// Used to update an environment in a project
+    /// </summary>
+    public sealed class UpdateEnvironmentRequest
+    {
+        [JsonProperty("environment_id")]
+        public int EnvironmentId { get; set; }
+
+        [JsonProperty("external_url")]
+        public Uri ExternalUrl { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateEnvironmentRequest"/> class
+        /// </summary>
+        /// <param name="environmentId">The ID of the environment</param>
+        /// <param name="externalUrl">The new external URL</param>
+        public UpdateEnvironmentRequest(int environmentId, Uri externalUrl)
+        {
+            Guard.NotNullOrDefault(environmentId, nameof(environmentId));
+            Guard.NotNullOrDefault(externalUrl, nameof(externalUrl));
+
+            EnvironmentId = environmentId;
+            ExternalUrl = externalUrl;
+        }
+    }
+}

--- a/src/GitLabApiClient/Models/Environments/Responses/Environment.cs
+++ b/src/GitLabApiClient/Models/Environments/Responses/Environment.cs
@@ -1,0 +1,30 @@
+using System;
+using GitLabApiClient.Models.Environments.Responses;
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.Environments.Responses
+{
+    public class Environment
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("slug")]
+        public string Slug { get; set; }
+
+        [JsonProperty("external_url")]
+        public Uri ExternalUrl { get; set; }
+
+        [JsonProperty("state")]
+        public EnvironmentState State { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+}

--- a/src/GitLabApiClient/Models/Environments/Responses/EnvironmentState.cs
+++ b/src/GitLabApiClient/Models/Environments/Responses/EnvironmentState.cs
@@ -1,0 +1,8 @@
+﻿namespace GitLabApiClient.Models.Environments.Responses
+{
+    public enum EnvironmentState
+    {
+        Available,
+        Stopped
+    }
+}

--- a/test/GitLabApiClient.Test/EnvironmentsTest.cs
+++ b/test/GitLabApiClient.Test/EnvironmentsTest.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GitLabApiClient.Internal.Queries;
+using GitLabApiClient.Models.Environments.Requests;
+using GitLabApiClient.Models.Environments.Responses;
+using Xunit;
+using static GitLabApiClient.Test.Utilities.GitLabApiHelper;
+using Environment = GitLabApiClient.Models.Environments.Responses.Environment;
+
+namespace GitLabApiClient.Test
+{
+    [Trait("Category", "LinuxIntegration")]
+    [Collection("GitLabContainerFixture")]
+    public class EnvironmentsTest
+    {
+        private readonly EnvironmentClient _sut = new EnvironmentClient(GetFacade(), new EnvironmentsQueryBuilder());
+
+        [Fact]
+        public async Task CreatedEnvironmentCanBeUpdated()
+        {
+            //arrange
+            const string testEnvironment = "Test Env Name";
+            var externalUrl = new Uri("https://dev.testingthis.com");
+            var createdEnvironment = await _sut.CreateAsync(TestProjectTextId,
+                new CreateEnvironmentRequest(testEnvironment, externalUrl));
+
+            //act
+            var updatedExternalUrl = new Uri("https://beta.testingthis.com");
+            var updatedEnvironment = await _sut.UpdateAsync(TestProjectTextId, 
+                new UpdateEnvironmentRequest(createdEnvironment.Id, updatedExternalUrl));
+
+            //assert
+            updatedEnvironment.Should().Match<Environment>(i =>
+                i.Name == testEnvironment &&
+                i.ExternalUrl == updatedExternalUrl);
+        }
+
+        [Fact]
+        public async Task CreatedEnvironmentCanBeFetched()
+        {
+            //arrange
+            const string testEnvironment = "Test Env Name";
+            var externalUrl = new Uri("https://dev.testingthis.com");
+            var createdEnvironment = await _sut.CreateAsync(TestProjectTextId,
+                new CreateEnvironmentRequest(testEnvironment, externalUrl));
+
+            //act
+            var fetchedEnvironment = await _sut.GetAsync(TestProjectTextId, createdEnvironment.Id);
+
+            //assert
+            fetchedEnvironment.Should().Match<Environment>(i =>
+                i.Name == testEnvironment &&
+                i.ExternalUrl == externalUrl);
+        }
+
+        [Fact]
+        public async Task CreatedEnvironmentCanBeListed()
+        {
+            //arrange
+            const string testEnvironment = "Test Env Name";
+            var externalUrl = new Uri("https://dev.testingthis.com");
+            var createdEnvironment = await _sut.CreateAsync(TestProjectTextId,
+                new CreateEnvironmentRequest(testEnvironment, externalUrl));
+
+            //act
+            var environmentList = await _sut.GetAsync(TestProjectTextId);
+
+            //assert
+            environmentList.Should().Contain(i =>
+                i.Name == testEnvironment &&
+                i.ExternalUrl == externalUrl);
+        }
+
+        [Fact]
+        public async Task CreatedEnvironmentCanBeStopped()
+        {
+            //arrange
+            const string testEnvironment = "Test Env Name";
+            var externalUrl = new Uri("https://dev.testingthis.com");
+            var createdEnvironment = await _sut.CreateAsync(TestProjectTextId,
+                new CreateEnvironmentRequest(testEnvironment, externalUrl));
+
+            //act
+            await _sut.StopAsync(TestProjectTextId, createdEnvironment.Id);
+
+            //assert
+            var fetchedEnvironment = await _sut.GetAsync(TestProjectTextId);
+            fetchedEnvironment.Should().Contain(i =>
+               i.Name == testEnvironment &&
+               i.ExternalUrl == externalUrl &&
+               i.State == EnvironmentState.Stopped);
+        }
+
+        [Fact]
+        public async Task CreatedEnvironmentCanBeDeleted()
+        {
+            //arrange
+            const string testEnvironment = "Test Env Name";
+            var externalUrl = new Uri("https://dev.testingthis.com");
+            var createdEnvironment = await _sut.CreateAsync(TestProjectTextId,
+                new CreateEnvironmentRequest(testEnvironment, externalUrl));
+
+            //act
+            await _sut.DeleteAsync(TestProjectTextId, createdEnvironment.Id);
+
+            //assert
+            var fetchedEnvironment = await _sut.GetAsync(TestProjectTextId);
+            fetchedEnvironment.Should().BeEmpty();
+        }
+    }
+}

--- a/test/GitLabApiClient.Test/Internal/Queries/EnvironmentsQueryBuilderTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Queries/EnvironmentsQueryBuilderTest.cs
@@ -1,0 +1,64 @@
+using System;
+using FluentAssertions;
+using GitLabApiClient.Internal.Queries;
+using GitLabApiClient.Models.Environments.Requests;
+using GitLabApiClient.Models.Environments.Responses;
+using Xunit;
+
+namespace GitLabApiClient.Test.Internal.Queries
+{
+    public class EnvironmentsQueryBuilderTest
+    {
+        [Fact]
+        public void NameQueryBuilt()
+        {
+            var sut = new EnvironmentsQueryBuilder();
+
+            string query = sut.Build(
+                "https://gitlab.com/api/v4/projects/projectId/environments",
+                new EnvironmentsQueryOptions()
+                {
+                    Name = "Test Env Name",
+                    States = EnvironmentState.Available
+                });
+
+            query.Should().Be("https://gitlab.com/api/v4/projects/projectId/environments?" +
+                              "name=Test%20Env%20Name&" +
+                              "states=available");
+        }
+
+        [Fact]
+        public void SearchQueryBuilt()
+        {
+            var sut = new EnvironmentsQueryBuilder();
+
+            string query = sut.Build(
+                "https://gitlab.com/api/v4/projects/projectId/environments",
+                new EnvironmentsQueryOptions()
+                {
+                    States = EnvironmentState.Available,
+                    Search = "filter env"
+                });
+
+            query.Should().Be("https://gitlab.com/api/v4/projects/projectId/environments?" +
+                              "search=filter%20env&" +
+                              "states=available");
+        }
+
+        [Fact]
+        public void NameAndSearchMutuallyExclusive()
+        {
+            var sut = new EnvironmentsQueryBuilder();
+
+            Assert.Throws<InvalidOperationException>(()=>
+                    sut.Build(
+                    "https://gitlab.com/api/v4/projects/projectId/environments",
+                    new EnvironmentsQueryOptions()
+                    {
+                        Name = "Test Env Name",
+                        States = EnvironmentState.Available,
+                        Search = "filter env"
+                    }));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the [GitLab Environments API](https://docs.gitlab.com/ee/api/environments.html).

I attempted to follow the established coding patterns precisely.

I added some unit tests for URL building. I attempted to add the functional tests but my local docker is not setup to execute them.

I performed manual testing of the querying using LINQPad.