### PR TITLE
Tag list on jobs

### DIFF
--- a/src/GitLabApiClient/Models/Job/Responses/Job.cs
+++ b/src/GitLabApiClient/Models/Job/Responses/Job.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using GitLabApiClient.Models.Commits.Responses;
 using GitLabApiClient.Models.Pipelines.Responses;
 using GitLabApiClient.Models.Runners.Responses;
@@ -56,5 +57,8 @@ namespace GitLabApiClient.Models.Job.Responses
 
         [JsonProperty("web_url")]
         public string WebUrl { get; set; }
+
+        [JsonProperty("tag_list")]
+        public IList<string> TagList { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Job/Responses/Job.cs
+++ b/src/GitLabApiClient/Models/Job/Responses/Job.cs
@@ -28,7 +28,7 @@ namespace GitLabApiClient.Models.Job.Responses
         public DateTime? FinishedAt { get; set; }
 
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }


### PR DESCRIPTION
Gitlab returns a list of tags for each job. I have added it to the Job response.
Also the id field on a job has been changed to a string, as the id is larger than what can be contained in an integer.