### PR TITLE
Added 'source' and ''tag_list' fields and fixed the type of the 'Id' field

### DIFF
--- a/src/GitLabApiClient/GitLabApiClient.csproj
+++ b/src/GitLabApiClient/GitLabApiClient.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild >true</ContinuousIntegrationBuild>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 

--- a/src/GitLabApiClient/Internal/Queries/PipelineQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/PipelineQueryBuilder.cs
@@ -62,6 +62,11 @@ namespace GitLabApiClient.Internal.Queries
             {
                 query.Add("username", options.TriggeredBy);
             }
+
+            if (options.Source.HasValue)
+            {
+                query.Add("source", options.Source.ToLowerCaseString());
+            }
         }
 
         #endregion

--- a/src/GitLabApiClient/Models/Job/Responses/Job.cs
+++ b/src/GitLabApiClient/Models/Job/Responses/Job.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using GitLabApiClient.Models.Commits.Responses;
 using GitLabApiClient.Models.Pipelines.Responses;
 using GitLabApiClient.Models.Runners.Responses;
@@ -56,5 +57,8 @@ namespace GitLabApiClient.Models.Job.Responses
 
         [JsonProperty("web_url")]
         public string WebUrl { get; set; }
+
+        [JsonProperty("tag_list")]
+        public IList<string> TagList { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Job/Responses/Job.cs
+++ b/src/GitLabApiClient/Models/Job/Responses/Job.cs
@@ -28,7 +28,7 @@ namespace GitLabApiClient.Models.Job.Responses
         public DateTime? FinishedAt { get; set; }
 
         [JsonProperty("id")]
-        public int Id { get; set; }
+        public string Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/GitLabApiClient/Models/Pipelines/PipelineSource.cs
+++ b/src/GitLabApiClient/Models/Pipelines/PipelineSource.cs
@@ -1,0 +1,36 @@
+using System.Runtime.Serialization;
+
+namespace GitLabApiClient.Models.Pipelines
+{
+    public enum PipelineSource
+    {
+        [EnumMember(Value = "push")]
+        Push,
+        [EnumMember(Value = "web")]
+        Web,
+        [EnumMember(Value = "trigger")]
+        Trigger,
+        [EnumMember(Value = "schedule")]
+        Schedule,
+        [EnumMember(Value = "api")]
+        Api,
+        [EnumMember(Value = "external")]
+        External,
+        [EnumMember(Value = "pipeline")]
+        Pipeline,
+        [EnumMember(Value = "chat")]
+        Chat,
+        [EnumMember(Value = "webide")]
+        Webide,
+        [EnumMember(Value = "merge_request_event")]
+        MergeRequestEvent,
+        [EnumMember(Value = "external_pull_request_event")]
+        ExternalPullRequestEvent,
+        [EnumMember(Value = "parent_pipeline")]
+        ParentPipeline,
+        [EnumMember(Value = "ondemand_dast_scan")]
+        OndemandDastScan,
+        [EnumMember(Value = "ondemand_dast_validation")]
+        OndemandDastValidation
+    }
+}

--- a/src/GitLabApiClient/Models/Pipelines/Requests/PipelineQueryOptions.cs
+++ b/src/GitLabApiClient/Models/Pipelines/Requests/PipelineQueryOptions.cs
@@ -55,5 +55,10 @@ namespace GitLabApiClient.Models.Pipelines.Requests
         ///     The username of the user who triggered pipelines
         /// </summary>
         public string TriggeredBy { get; set; }
+
+        /// <summary>
+        ///     How the pipeline was triggered
+        /// </summary>
+        public PipelineSource? Source { get; set; }
     }
 }

--- a/src/GitLabApiClient/Models/Pipelines/Responses/PipelineDetail.cs
+++ b/src/GitLabApiClient/Models/Pipelines/Responses/PipelineDetail.cs
@@ -52,5 +52,8 @@ namespace GitLabApiClient.Models.Pipelines.Responses
 
         [JsonProperty("coverage")]
         public string Coverage { get; set; }
+
+        [JsonProperty("source")]
+        public PipelineSource? Source { get; set; }
     }
 }

--- a/test/GitLabApiClient.Test/Internal/Queries/PipelineQueryBuilderTest.cs
+++ b/test/GitLabApiClient.Test/Internal/Queries/PipelineQueryBuilderTest.cs
@@ -24,7 +24,8 @@ namespace GitLabApiClient.Test.Internal.Queries
                     Status = PipelineStatus.Failed,
                     Scope = PipelineScope.Pending,
                     Order = PipelineOrder.UserId,
-                    SortOrder = SortOrder.Ascending
+                    SortOrder = SortOrder.Ascending,
+                    Source = PipelineSource.MergeRequestEvent
                 });
 
             query.Should().Be("https://https://gitlab.com/api/v4/pipelines?" +
@@ -34,7 +35,9 @@ namespace GitLabApiClient.Test.Internal.Queries
                               "&status=failed" +
                               "&scope=pending" +
                               "&order_by=user_id" +
-                              "&sort=asc");
+                              "&sort=asc" +
+                              "&source=merge_request_event"
+            );
         }
     }
 }


### PR DESCRIPTION
Added the 'Source' element to pipelines.
Both in the request and the detailed response.

Changed the type of the Id field on the Job type from int to string (id's are above the int limit now)

Added the 'tag_list' field to the Job response