### PR TITLE
Fix Protect/Unprotect Git Operation to avoid error

### DIFF
--- a/src/GitLabApiClient/Models/Branches/Requests/ProtectBranchRequest.cs
+++ b/src/GitLabApiClient/Models/Branches/Requests/ProtectBranchRequest.cs
@@ -25,9 +25,10 @@ namespace GitLabApiClient.Models.Branches.Requests
         {
             Guard.NotEmpty(name, nameof(name));
 
-            PushAccessLevel = pushAccessLevel.ToString();
-            MergeAccessLevel = mergeAccessLevel.ToString();
-            UnprotectAccessLevel = unprotectAccessLevel.ToString();
+            Name = name;
+            PushAccessLevel = (int)pushAccessLevel;
+            MergeAccessLevel = (int)mergeAccessLevel;
+            UnprotectAccessLevel = (int)unprotectAccessLevel;
         }
 
         /// <summary>


### PR DESCRIPTION
Hi! Currently the Protect/Unprotect branch feature is not working in the latest version, I get a validation errors..
I already fixed that with this simple update...

Thanks!