### PR TITLE
Fix issue where confidential query option is not applied

### DIFF
--- a/src/GitLabApiClient/Internal/Queries/IssuesQueryBuilder.cs
+++ b/src/GitLabApiClient/Internal/Queries/IssuesQueryBuilder.cs
@@ -44,8 +44,7 @@ namespace GitLabApiClient.Internal.Queries
             if (!options.Filter.IsNullOrEmpty())
                 query.Add("search", options.Filter);
 
-            if (options.IsConfidential)
-                query.Add("confidential", true);
+            query.Add("confidential", options.IsConfidential);
 
             if (options.CreatedBefore.HasValue)
                 query.Add("created_before", options.CreatedBefore.Value);

--- a/test/GitLabApiClient.Test/IssuesClientTest.cs
+++ b/test/GitLabApiClient.Test/IssuesClientTest.cs
@@ -120,6 +120,27 @@ namespace GitLabApiClient.Test
         }
 
         [Fact]
+        public async Task CreatedConfidentialIssueWillBeIgnored()
+        {
+            //arrange
+            string title = Guid.NewGuid().ToString();
+
+            var issue = await _sut.CreateAsync(TestProjectTextId, new CreateIssueRequest(title)
+            {
+                Assignees = new List<int> { 1 },
+                Confidential = true,
+                Description = "Description",
+                Labels = new List<string> { "Label1" }
+            });
+
+            //act
+            var commonIssues = await _sut.GetAllAsync(options: o => o.IsConfidential = false);
+
+            //assert
+            commonIssues.Should().HaveCount(0);
+        }
+
+        [Fact]
         public async Task CreatedIssueNoteCanBeRetrieved()
         {
             //arrange


### PR DESCRIPTION
This PR will resolve the issue where the confidential option in `IssuesQueryOptions` is not applied in the query. Even though confidential is set to `false` by default, the returned result still contains confidential issues.