### PR TITLE
[API] Add API client to retrieve Label Events for Issues, Epics, and Merge Requests

### DIFF
--- a/src/GitLabApiClient/IResourceLabelEventsClient.cs
+++ b/src/GitLabApiClient/IResourceLabelEventsClient.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Models.LabelEvents.Responses;
+using GitLabApiClient.Models.Projects.Responses;
+
+namespace GitLabApiClient
+{
+    public interface IResourceLabelEventsClient
+    {
+        /// <summary>
+        /// Retrieves label events from issues.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="eventResourceType">Resource type (supported resources: Issues, Epics, MergeRequests)</param>
+        /// <param name="resourceId">The IID of an issue, ID of an Epic, or IID of a Merge Request</param>
+        /// <returns>Label Events for the given resource type and id</returns>
+        Task<IList<LabelEvent>> GetAllAsync(ProjectId projectId, EventResourceType eventResourceType, int resourceId);
+
+        /// <summary>
+        /// Retrieves a single label event from issues.
+        /// </summary>
+        /// <param name="projectId">The ID, path or <see cref="Project"/> of the project.</param>
+        /// <param name="eventResourceType">Resource type (supported resources: Issues, Epics, MergeRequests)</param>
+        /// <param name="resourceId">The IID of an issue, ID of an Epic, or IID of a Merge Request</param>
+        /// <param name="eventId">The ID of a label event</param>
+        /// <returns>Label Events for the given issue Id</returns>
+        Task<IList<LabelEvent>> GetAsync(ProjectId projectId, EventResourceType eventResourceType, int resourceId,
+            int eventId);
+    }
+}

--- a/src/GitLabApiClient/Models/LabelEvents/Responses/EventResourceType.cs
+++ b/src/GitLabApiClient/Models/LabelEvents/Responses/EventResourceType.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel;
+
+namespace GitLabApiClient.Models.LabelEvents.Responses
+{
+    public enum EventResourceType
+    {
+        [Description("issues")]
+        Issues,
+        [Description("epics")]
+        Epics,
+        [Description("merge_requests")]
+        MergeRequests
+    }
+
+    internal static class EnumExtensions
+    {
+        public static string GetDescription(this Enum value)
+        {
+            var field = value.GetType().GetField(value.ToString());
+            var attributes = (DescriptionAttribute[])field.GetCustomAttributes(typeof(DescriptionAttribute), false);
+            return attributes.Length > 0 ? attributes[0].Description : value.ToString();
+        }
+    }
+}

--- a/src/GitLabApiClient/Models/LabelEvents/Responses/LabelEvent.cs
+++ b/src/GitLabApiClient/Models/LabelEvents/Responses/LabelEvent.cs
@@ -1,0 +1,18 @@
+using GitLabApiClient.Models.Projects.Responses;
+using GitLabApiClient.Models.Users.Responses;
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models.LabelEvents.Responses
+{
+    public class LabelEvent : Resource
+    {
+        [JsonProperty("user")]
+        public User User { get; set; }
+
+        [JsonProperty("label")]
+        public Label Label { get; set; }
+
+        [JsonProperty("action")]
+        public string Action { get; set; }
+    }
+}

--- a/src/GitLabApiClient/Models/Resource.cs
+++ b/src/GitLabApiClient/Models/Resource.cs
@@ -1,0 +1,22 @@
+using System;
+using Newtonsoft.Json;
+
+namespace GitLabApiClient.Models
+{
+    public class Resource
+    {
+        internal Resource() { }
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        [JsonProperty("resource_type")]
+        public string ResourceType { get; set; }
+
+        [JsonProperty("resource_id")]
+        public string ResourceId { get; set; }
+    }
+}

--- a/src/GitLabApiClient/ResourceLabelEventsClient.cs
+++ b/src/GitLabApiClient/ResourceLabelEventsClient.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GitLabApiClient.Internal.Http;
+using GitLabApiClient.Internal.Paths;
+using GitLabApiClient.Models.LabelEvents.Responses;
+
+namespace GitLabApiClient
+{
+    public sealed class ResourceLabelEventsClient : IResourceLabelEventsClient
+    {
+        private readonly GitLabHttpFacade _httpFacade;
+
+        internal ResourceLabelEventsClient(GitLabHttpFacade httpFacade) =>
+            _httpFacade = httpFacade;
+
+        public async Task<IList<LabelEvent>> GetAllAsync(
+            ProjectId projectId,
+            EventResourceType eventResourceType,
+            int resourceId)
+        {
+            string query =
+                $"projects/{projectId}/{eventResourceType.GetDescription()}/{resourceId}/resource_label_events";
+            return await _httpFacade.GetPagedList<LabelEvent>(query);
+        }
+
+        public async Task<IList<LabelEvent>> GetAsync(ProjectId projectId,
+            EventResourceType eventResourceType,
+            int resourceId,
+            int eventId)
+        {
+            string query =
+                $"projects/{projectId}/{eventResourceType.GetDescription()}/{resourceId}/resource_label_events/{eventId}";
+            return await _httpFacade.GetPagedList<LabelEvent>(query);
+        }
+    }
+}

--- a/test/GitLabApiClient.Test/ResourceLabelEventsClientTest.cs
+++ b/test/GitLabApiClient.Test/ResourceLabelEventsClientTest.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GitLabApiClient.Internal.Queries;
+using GitLabApiClient.Models.Issues.Requests;
+using GitLabApiClient.Models.LabelEvents.Responses;
+using GitLabApiClient.Test.Utilities;
+using Xunit;
+
+namespace GitLabApiClient.Test
+{
+    [Trait("Category", "LinuxIntegration")]
+    [Collection("GitLabContainerFixture")]
+    public class ResourceLabelEventsClientTest : IAsyncLifetime
+    {
+        private readonly MergeRequestsClient _mergeRequestsClient = new MergeRequestsClient(
+            GitLabApiHelper.GetFacade(), new MergeRequestsQueryBuilder(), new ProjectMergeRequestsQueryBuilder(),
+            new ProjectMergeRequestsNotesQueryBuilder());
+
+        private readonly IssuesClient _issuesClient = new IssuesClient(
+            GitLabApiHelper.GetFacade(), new IssuesQueryBuilder(), new ProjectIssueNotesQueryBuilder());
+
+        private readonly ResourceLabelEventsClient _sut = new ResourceLabelEventsClient(GitLabApiHelper.GetFacade());
+
+        [Fact]
+        public async Task IssuesLabelEventsCanBeRetrieved()
+        {
+            var createdIssue = await _issuesClient.CreateAsync(
+                GitLabApiHelper.TestProjectTextId, new CreateIssueRequest("Title1")
+            {
+                Assignees = new List<int> { 1 },
+                Confidential = true,
+                Description = "Description1",
+                Labels = new[] { "Label1" },
+                MilestoneId = 2,
+                DiscussionToResolveId = 3,
+                MergeRequestIdToResolveDiscussions = 4
+            });
+
+            var labelEvents = await _sut.GetAllAsync(
+                GitLabApiHelper.TestProjectTextId,
+                  EventResourceType.Issues,
+                  createdIssue.Iid
+                );
+
+            labelEvents.Single().Should().Match<LabelEvent>(actual =>
+                actual.Label.Name == "Label1");
+        }
+
+        public Task InitializeAsync() => throw new System.NotImplementedException();
+        public Task DisposeAsync() => throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
### [DRAFT]

### Why
Current client does not have certain API endpoints implemented, specifically ones to retrieve label events as described in [GitLab documentation here](https://docs.gitlab.com/ee/api/resource_label_events.html).

### What
- Add two endpoints to retrieve label events for an MR, Issue, or Epic.
- Add new API types to support the endpoints

### Note
This is a WIP